### PR TITLE
add option to disable server prompt coloring

### DIFF
--- a/pupy/pupy.conf
+++ b/pupy/pupy.conf
@@ -6,6 +6,7 @@ certfile = crypto/cert.pem
 
 [cmdline]
 display_banner = yes
+colors = yes
 
 [aliases]
 info = get_info


### PR DESCRIPTION
Right now server doesn't display correctly on Windows prompt with colors enabled, so I made a short patch.
The color output needs some refactoring first for a less hacky solution though.