### PR TITLE
Clients command renamed to sessions, added notifications on session connect/disconnect

### DIFF
--- a/pupy/pupylib/PupyCmd.py
+++ b/pupy/pupylib/PupyCmd.py
@@ -428,7 +428,7 @@ class PupyCmd(cmd.Cmd):
 			self.display_error(traceback.format_exc())
 
 	def do_python(self,arg):
-		""" start interacting with the server local python interpreter (for debugging purposes). Auto-completion available. """
+		""" start the local python interpreter (for debugging purposes) """
 		orig_exit=builtins.exit
 		orig_quit=builtins.quit
 		def disabled_exit(*args, **kwargs):
@@ -524,7 +524,7 @@ class PupyCmd(cmd.Cmd):
 			error=pj.interactive_wait()
 			if error and not modjobs:
 				pj.stop()
-				
+
 		except KeyboardInterrupt:
 			self.display_warning("interrupting job ... (please wait)")
 			pj.interrupt()

--- a/pupy/pupylib/PupyCmd.py
+++ b/pupy/pupylib/PupyCmd.py
@@ -368,6 +368,7 @@ class PupyCmd(cmd.Cmd):
 		arg_parser = PupyArgumentParser(prog='sessions', description=self.do_sessions.__doc__)
 		arg_parser.add_argument('-i', '--interact', metavar='<filter>', help="change the default --filter value for other commands")
 		arg_parser.add_argument('-g', '--global-reset', action='store_true', help="reset --interact to the default global behavior")
+		arg_parser.add_argument('-k', '--kill', metavar='<id>', type=int, help='Kill the selected session')
 		try:
 			modargs=arg_parser.parse_args(shlex.split(arg))
 		except PupyModuleExit:
@@ -378,7 +379,14 @@ class PupyCmd(cmd.Cmd):
 			self.display_success("default filter reset to global !")
 		elif modargs.interact:
 			self.default_filter=modargs.interact
-			self.display_success("default filter set to %s"%self.default_filter)
+			self.display_success("default filter set to {}".format(self.default_filter))
+		elif modargs.kill:
+			selected_client = self.pupsrv.get_clients(modargs.kill)
+			if selected_client:
+				try:
+					selected_client[0].conn.exit()
+				except Exception:
+					pass
 		else:
 			client_list=self.pupsrv.get_clients_list()
 			self.display(PupyCmd.table_format([x.desc for x in client_list], wl=["id", "user", "hostname", "platform", "release", "os_arch", "address"]))

--- a/pupy/pupylib/PupyServer.py
+++ b/pupy/pupylib/PupyServer.py
@@ -24,6 +24,8 @@ import modules
 import logging
 from .PupyErrors import PupyModuleExit, PupyModuleError
 from .PupyJob import PupyJob
+from .PupyCmd import color_real
+
 try:
 	import ConfigParser as configparser
 except ImportError:
@@ -127,12 +129,20 @@ class PupyServer(threading.Thread):
 				"pid" : l[7],
 				"address" : conn._conn._config['connid'].split(':')[0],
 			}, self))
-			self.current_id+=1
+
+			addr = conn.modules['pupy'].get_connect_back_host()
+			server_ip, server_port = addr.rsplit(':', 1)
+			client_ip, client_port = conn._conn._config['connid'].split(':')
+
+			print color_real('[*]', 'blue'), "Session {} opened ({}:{} -> {}:{})".format(self.current_id, server_ip, server_port, client_ip, client_port)
+
+			self.current_id += 1
 
 	def remove_client(self, client):
 		with self.clients_lock:
 			for i,c in enumerate(self.clients):
 				if c.conn is client:
+					print color_real('[*]', 'blue'), 'Session {} closed'.format(self.clients[i].desc['id'])
 					del self.clients[i]
 					break
 
@@ -218,7 +228,6 @@ class PupyServer(threading.Thread):
 		job.id=self.jobs_id
 		self.jobs[self.jobs_id]=job
 		self.jobs_id+=1
-
 
 	def get_job(self, job_id):
 		try:


### PR DESCRIPTION
The changes can be summarized by this output:
```
>> [*] Session 1 opened (192.168.20.79:443 -> 192.168.20.103:49745)

>> sessions
id  user         hostname  platform  release  os_arch  address         
-----------------------------------------------------------------------
1   adrugdealer  DEVBOX    Windows   8        AMD64    192.168.20.103
>> sessions -k 1
[*] Session 1 closed
 >>exit
```
When a new session is established or disconnected a message is shown (meterpreter style) ,  very useful feedback IMHO

Also the ```clients``` command has been renamed to ```sessions```, it also allows you to kill a session with the ```-k``` argument