### PR TITLE
smarter library builder script, can pack its own zip

### DIFF
--- a/client/additional_imports.py
+++ b/client/additional_imports.py
@@ -41,3 +41,4 @@ import threading
 import time
 import urllib
 import urllib2
+import socks

--- a/client/build_library_helper.py
+++ b/client/build_library_helper.py
@@ -3,6 +3,8 @@ from distutils.core import setup
 import py2exe
 import os
 from glob import glob
+import zipfile
+import shutil
 
 """
 This setup is not meant to build pupy stubs, but only to generate an adequate library.zip to embed in the real exe/dll stub
@@ -11,8 +13,16 @@ please don't use this if you don't want to recompile from sources
 NOTE: I had to manually change pyreadline/console/console.py to console2.py and edit __init__.py to change the import because I had a conflict 
 
 """
-if not (len(sys.argv)==2 and sys.argv[1]=="genzip"):
+if not (len(sys.argv)==3 and sys.argv[1]=="genzip"):
 	exit("This setup is not meant to build pupy stubs, but only to generate an adequate library.zip to embed in the real exe/dll stub\nplease don't use this if you don't want to recompile from sources")
+if sys.argv[2] == 'x86':
+	outname = 'x86'
+	platform = 'x86'
+elif sys.argv[2] == 'x64':
+	outname = 'x64'
+	platform = 'amd64'
+else:
+	exit('unsupported platform')
 sys.argv=[sys.argv[0],"py2exe"]
 
 
@@ -24,8 +34,36 @@ setup(
 	options={ "py2exe" : {
 				"packages":['additional_imports'],
 				"compressed" : True,
-				"bundle_files" : 2, #3 = don't bundle (default) 2 = bundle everything but the Python interpreter 1 = bundle everything
+				"bundle_files" : 3, #3 = don't bundle (default) 2 = bundle everything but the Python interpreter 1 = bundle everything
+				"excludes": ["Tkinter"]
 				}
 		}
 )
+
+excluded_files = [
+	'crypt32.dll',
+	'library.zip',
+	'mswsock.dll',
+	'python27.dll',
+]
+def zwalk(path, zf):
+	for root, dirs, files in os.walk(path):
+		for file in files:
+			if file.lower() in excluded_files:
+				pass
+			else:
+				zf.write(os.path.join(root, file))
+
+			
+with zipfile.ZipFile('sources/resources/library%s.zip' % outname, 'w', zipfile.ZIP_DEFLATED) as zf:
+	root = os.getcwd()
+	os.chdir('build/bdist.win-%s/winexe/collect-2.7' % platform)
+	zwalk('.', zf)
+	os.chdir('%s/dist' % root)
+	zwalk('.', zf)
+	
+print 'cleaning up'
+os.chdir(root)
+shutil.rmtree('build')
+shutil.rmtree('dist')	
 


### PR DESCRIPTION
The obfsproxy integration is not ready yet, but once it's ready we can add twisted to import list and have a full integrated library.
I managed to pack the x64 library down to ~4MB with this script.
Could @n1nj4sec and @byt3bl33d3r check if any module is missing?