### PR TITLE
module file path sent to client should only contain "/" as separator

### DIFF
--- a/pupy/pupylib/PupyClient.py
+++ b/pupy/pupylib/PupyClient.py
@@ -102,7 +102,8 @@ class PupyClient(object):
 			For other platforms : loading .so in memory is not supported yet.
 		"""
 		modules_dic={}
-		start_path=module_name.replace(".",os.sep)
+		# start path should only use "/" as separator
+		start_path=module_name.replace(".", "/")
 		package_found=False
 		package_path=None
 		for search_path in self.get_packages_path():
@@ -123,7 +124,7 @@ class PupyClient(object):
 							with open(filepath,'rb') as f:
 								module_code=f.read()
 							cur=""
-							for rep in start_path.split(os.sep)[:-1]:
+							for rep in start_path.split("/")[:-1]:
 								if not cur+rep+"/__init__.py" in modules_dic:
 									modules_dic[rep+"/__init__.py"]=""
 								cur+=rep+"/"


### PR DESCRIPTION
This PR fixes an error when trying to use screenshot/msgbox if running the server on Windows.

```
>> run screenshot
[-] No module named screenshot

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "rpyc\core\protocol.pyc", line 305, in _dispatch_request
  File "rpyc\core\protocol.pyc", line 547, in _handle_callattr
  File "rpyc\core\service.pyc", line 118, in __getitem__
  File "<string>", line 59, in exposed_getmodule
ImportError: No module named screenshot
```

This is caused by the server sending a file path containing "\" to the client, confusing it.