### PR TITLE
update helper for automatic library package patching

### DIFF
--- a/client/build_library_helper.py
+++ b/client/build_library_helper.py
@@ -26,6 +26,10 @@ else:
 sys.argv=[sys.argv[0],"py2exe"]
 
 
+# put necessary library patches/includes/whatever in this directory
+sys.path.insert(0, "sources/resources/library_patches")
+
+
 setup(
 	data_files = [(".", glob(r'.\RESOURCES_x86\msvcr90.dll'))],
 	console=['reverse_ssl.py'],


### PR DESCRIPTION
This PR lets you put Python import patches in `sources/resources/library_patches` as needed and it will be pulled into the library package automatically on setup.py import resolution.