### PR TITLE
New 'pyinst' output format for making a .py which can be used by pyinstaller

### DIFF
--- a/pupy/conf/imports_done.py
+++ b/pupy/conf/imports_done.py
@@ -1,0 +1,75 @@
+from collections import OrderedDict
+from Crypto.Cipher import AES
+from Crypto.Hash import HMAC
+from Crypto.Hash import SHA256
+from Crypto.Hash import SHA256, HMAC
+from Crypto import Random
+from Crypto.Protocol.KDF import PBKDF2
+from Crypto.Util import Counter
+from cStringIO import StringIO
+from itertools import izip, starmap
+from operator import xor
+from StringIO import StringIO
+from struct import Struct
+import argparse
+import base64
+import binascii
+import bz2
+import code
+import collections
+import configparser
+import copy
+import cPickle
+import Crypto.Cipher
+import Crypto.Cipher.AES
+import Crypto.Hash.HMAC
+import Crypto.Hash.SHA256
+import Crypto.Util.Counter
+import datetime
+import errno, stat
+import fractions
+import __future__
+import getpass
+import glob
+import hashlib
+import hmac
+import imp
+import importlib
+import inspect
+import json
+import logging
+import math
+import multiprocessing
+import new 
+import os
+import pkgutil
+import platform
+import Queue
+import random
+import re
+import rsa
+import shlex
+import shutil
+import site
+import socket
+import SocketServer
+import ssl
+import string
+import StringIO
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import traceback
+import urllib
+import urllib2
+import uuid
+import yaml
+import zlib
+if os.name == 'nt':
+    import ctypes
+    import ctypes.wintypes
+if os.name == 'posix':
+    import pty

--- a/pupy/pupygen.py
+++ b/pupy/pupygen.py
@@ -7,7 +7,7 @@ import logging, argparse, sys, os.path, re, shlex, random, string, zipfile, tarf
 from pupylib.utils.network import get_local_ip
 from pupylib.utils.term import colorize
 from pupylib.payloads.python_packer import gen_package_pickled_dic
-from pupylib.payloads.py_oneliner import serve_payload, pack_py_payload
+from pupylib.payloads.py_oneliner import serve_payload, pack_py_payload, getLinuxImportedModules
 from pupylib.utils.obfuscate import compress_encode_obfs
 from network.conf import transports, launchers
 from network.lib.base_launcher import LauncherError
@@ -254,7 +254,7 @@ class ListOptions(argparse.Action):
             print '\n'.join(["\t"+x for x in sc.get_help().split("\n")])
         exit()
 
-PAYLOAD_FORMATS=['apk', 'exe_x86', 'exe_x64', 'dll_x86', 'dll_x64', 'py', 'py_oneliner', 'ps1_oneliner']
+PAYLOAD_FORMATS=['apk', 'exe_x86', 'exe_x64', 'dll_x86', 'dll_x64', 'py', 'pyinst', 'py_oneliner', 'ps1_oneliner']
 if __name__=="__main__":
     if os.path.dirname(__file__):
         os.chdir(os.path.dirname(__file__))
@@ -331,12 +331,15 @@ if __name__=="__main__":
         if not outpath:
             outpath="pupy.apk"
         get_edit_apk(os.path.join("payload_templates","pupy.apk"), outpath, conf)
-    elif args.format=="py":
+    elif args.format=="py" or args.format=="pyinst":
+        linux_modules = ""
         if not outpath:
             outpath="payload.py"
+        if args.format=="pyinst" : 
+            linux_modules = getLinuxImportedModules()
         packed_payload=pack_py_payload(get_raw_conf(conf))
         with open(outpath, 'wb') as w:
-            w.write("#!/usr/bin/env python\n# -*- coding: UTF8 -*-\n"+packed_payload)
+            w.write("#!/usr/bin/env python\n# -*- coding: UTF8 -*-\n"+linux_modules+"\n"+packed_payload)
     elif args.format=="py_oneliner":
         packed_payload=pack_py_payload(get_raw_conf(conf))
         i=conf["launcher_args"].index("--host")+1

--- a/pupy/pupylib/payloads/py_oneliner.py
+++ b/pupy/pupylib/payloads/py_oneliner.py
@@ -13,6 +13,14 @@ from pupylib.payloads.python_packer import get_load_module_code, gen_package_pic
 
 ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),"..",".."))
 
+def getLinuxImportedModules():
+    '''
+    '''
+    lines = ""
+    with open(os.path.join(ROOT,"conf","imports_done.py")) as f:
+        lines=f.read()
+    return lines
+
 def pack_py_payload(conf):
     print colorize("[+] ","green")+"generating payload ..."
     fullpayload=[]
@@ -74,5 +82,3 @@ def serve_payload(payload, ip="0.0.0.0", port=8080, link_ip="<your_ip>"):
         print 'KeyboardInterrupt received, shutting down the web server'
         server.socket.close()
         exit()
-
-


### PR DESCRIPTION
New _pyinst_ output format for making a py file which can be used with _**pyinstaller**_.

Tested with connect+ssl options on Windows (wind7,x64) and Linux (Kali, x64).

It appends Python imports (used in the payload code) before the payload code in the py file.