### PR TITLE
Basic cmds

### DIFF
--- a/pupy/modules/cat.py
+++ b/pupy/modules/cat.py
@@ -6,7 +6,7 @@ __class_name__="cat"
 
 @config(cat="admin")
 class cat(PupyModule):
-	""" remove a file or a directory """
+	""" show contents of a file """
 
 	def init_argparse(self):
 		self.arg_parser = PupyArgumentParser(prog="cat", description=self.__doc__)		

--- a/pupy/modules/cat.py
+++ b/pupy/modules/cat.py
@@ -1,0 +1,18 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+from pupylib.utils.rpyc_utils import redirected_stdio
+
+__class_name__="cat"
+
+@config(cat="admin")
+class cat(PupyModule):
+	""" remove a file or a directory """
+
+	def init_argparse(self):
+		self.arg_parser = PupyArgumentParser(prog="cat", description=self.__doc__)		
+		self.arg_parser.add_argument('path', type=str, action='store')
+
+	def run(self, args):
+		self.client.load_package("pupyutils.basic_cmds")
+		with redirected_stdio(self.client.conn):
+		    self.client.conn.modules["pupyutils.basic_cmds"].cat(args.path)

--- a/pupy/modules/cd.py
+++ b/pupy/modules/cd.py
@@ -1,0 +1,18 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+from pupylib.utils.rpyc_utils import redirected_stdio
+
+__class_name__="cd"
+
+@config(cat="admin")
+class cd(PupyModule):
+    """ change directory """
+
+    def init_argparse(self):
+        self.arg_parser = PupyArgumentParser(prog="cd", description=self.__doc__)
+        self.arg_parser.add_argument('path', type=str, nargs='?', help='path of a specific directory')
+
+    def run(self, args):
+        self.client.load_package("pupyutils.basic_cmds")
+        with redirected_stdio(self.client.conn):
+            self.client.conn.modules["pupyutils.basic_cmds"].cd(args.path)

--- a/pupy/modules/cp.py
+++ b/pupy/modules/cp.py
@@ -1,0 +1,19 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+from pupylib.utils.rpyc_utils import redirected_stdio
+
+__class_name__="cp"
+
+@config(cat="admin")
+class cp(PupyModule):
+	""" copy file or directory """
+
+	def init_argparse(self):
+		self.arg_parser = PupyArgumentParser(prog="cp", description=self.__doc__)		
+		self.arg_parser.add_argument('src', type=str, action='store')
+		self.arg_parser.add_argument('dst', type=str, action='store')
+
+	def run(self, args):
+		self.client.load_package("pupyutils.basic_cmds")
+		with redirected_stdio(self.client.conn):
+		    self.client.conn.modules["pupyutils.basic_cmds"].cp(args.src, args.dst)

--- a/pupy/modules/ls.py
+++ b/pupy/modules/ls.py
@@ -1,0 +1,19 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+from pupylib.utils.rpyc_utils import redirected_stdio
+
+__class_name__="ls"
+
+@config(cat="admin")
+class ls(PupyModule):
+    """ list system files """
+
+    def init_argparse(self):
+        self.arg_parser = PupyArgumentParser(prog="ls", description=self.__doc__)
+        self.arg_parser.add_argument('path', type=str, nargs='?', help='path of a specific file')
+
+    def run(self, args):
+        self.client.load_package("pupyutils.basic_cmds")
+        with redirected_stdio(self.client.conn):
+            self.client.conn.modules["pupyutils.basic_cmds"].ls(args.path)
+

--- a/pupy/modules/mkdir.py
+++ b/pupy/modules/mkdir.py
@@ -1,0 +1,19 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+from pupylib.utils.rpyc_utils import redirected_stdio
+
+__class_name__="mkdir"
+
+@config(cat="admin")
+class mkdir(PupyModule):
+    """ create an empty directory """
+
+    def init_argparse(self):
+        self.arg_parser = PupyArgumentParser(prog="mkdir", description=self.__doc__)
+        self.arg_parser.add_argument('dir', type=str, help='directory name')
+
+    def run(self, args):
+        self.client.load_package("pupyutils.basic_cmds")
+        with redirected_stdio(self.client.conn):
+            self.client.conn.modules["pupyutils.basic_cmds"].mkdir(args.dir)
+

--- a/pupy/modules/mv.py
+++ b/pupy/modules/mv.py
@@ -1,0 +1,19 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+from pupylib.utils.rpyc_utils import redirected_stdio
+
+__class_name__="mv"
+
+@config(cat="admin")
+class mv(PupyModule):
+	""" move file or directory """
+
+	def init_argparse(self):
+		self.arg_parser = PupyArgumentParser(prog="mv", description=self.__doc__)		
+		self.arg_parser.add_argument('src', type=str, action='store')
+		self.arg_parser.add_argument('dst', type=str, action='store')
+
+	def run(self, args):
+		self.client.load_package("pupyutils.basic_cmds")
+		with redirected_stdio(self.client.conn):
+		    self.client.conn.modules["pupyutils.basic_cmds"].mv(args.src, args.dst)

--- a/pupy/modules/rm.py
+++ b/pupy/modules/rm.py
@@ -1,0 +1,18 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+from pupylib.utils.rpyc_utils import redirected_stdio
+
+__class_name__="rm"
+
+@config(cat="admin")
+class rm(PupyModule):
+	""" remove a file or a directory """
+
+	def init_argparse(self):
+		self.arg_parser = PupyArgumentParser(prog="rm", description=self.__doc__)		
+		self.arg_parser.add_argument('path', type=str, action='store')
+
+	def run(self, args):
+		self.client.load_package("pupyutils.basic_cmds")
+		with redirected_stdio(self.client.conn):
+		    self.client.conn.modules["pupyutils.basic_cmds"].rm(args.path)

--- a/pupy/packages/all/pupyutils/basic_cmds.py
+++ b/pupy/packages/all/pupyutils/basic_cmds.py
@@ -1,0 +1,152 @@
+# -*- coding: UTF8 -*-
+import os
+from datetime import datetime
+import shutil
+
+# -------------------------- For ls functions --------------------------
+
+def sizeof_fmt(num, suffix='B'):
+	try:
+		num = int(num)
+		for unit in ['','Ki','Mi','Gi','Ti','Pi','Ei','Zi']:
+			if abs(num) < 1024.0:
+				return "%3.1f %s%s" % (num, unit, suffix)
+			num /= 1024.0
+		return "%.1f %s%s" % (num, 'Yi', suffix)
+	except:
+		return '0.00 B'
+
+def list_file(real_name, path):
+	category = '      '
+	if os.path.isdir(path):
+		category = '<REP> '
+
+	try:
+		d = datetime.fromtimestamp(os.path.getmtime(path))
+		date = str(d.strftime("%d/%m/%y"))
+	except:
+		date = '00/00/00'
+	
+	try:
+		size = sizeof_fmt(os.path.getsize(path))
+		s = str(size)
+		while len(s) < 10:
+			s = s + ' '
+	except:
+		s =  '          '
+
+	return ' ' + date + '  ' + category + '  ' + s + '  ' + real_name + '\n'
+
+def list_dir(path):
+	output = ''
+	try:
+		ff = ""
+		for f in os.listdir(path):
+			ff += list_file(f, path + os.sep + f)
+	except:
+		ff = '\n[-] You need more permission to show the content of the file'
+	
+	return ff
+	
+def ls(path=None):
+	if not path:
+		path = "."
+	
+	if not os.path.exists(path):
+		print "[-] The path \"%s\" does not exist" % path
+		return
+
+	if os.path.isdir(path):
+		allfiles = list_dir(path)
+	elif os.path.isfile(path):
+		allfiles = list_file(path, os.getcwd() + os.sep + path)
+	
+	print "%s" % allfiles
+	
+# -------------------------- For cd function --------------------------
+
+def cd(path=None):
+	if not path:
+		home = os.path.expanduser("~")
+		os.chdir(home)
+		return
+	
+	path = os.path.join(os.getcwd(), path)
+	if os.path.isdir(path):
+		try:
+			os.chdir(path)
+		except:
+			print "[-] Permission denied to change to this directory"
+			
+	else:
+		print "[-] \"%s\" is not a repository" % path
+
+# -------------------------- For mkdir function --------------------------
+
+def mkdir(directory):
+	if not os.path.exists(directory):
+		os.makedirs(directory)
+	else:
+		print "[-] The directory \"%s\" already exists" % directory
+
+# -------------------------- For cp function --------------------------
+
+def cp(src, dst):
+	if dst.endswith('.'):
+		d = src.split(os.sep)
+		dst = os.path.abspath(os.path.join(dst, d[len(d)-1]))
+
+	if not os.path.exists(dst):
+		if os.path.exists(src):
+			if os.path.isdir(src):
+				shutil.copytree(src, dst)
+			else:
+				shutil.copyfile(src, dst)
+		else:
+			print "[-] The file \"%s\" does not exist" % src
+	else:
+		print "[-] The file \"%s\" already exists" % dst
+
+# -------------------------- For mv function --------------------------
+
+def mv(src, dst):
+	if dst.endswith('.'):
+		d = src.split(os.sep)
+		dst = os.path.abspath(os.path.join(dst, d[len(d)-1]))
+
+	if not os.path.exists(dst):
+		if os.path.exists(src):
+				shutil.move(src, dst)
+		else:
+			print "[-] The file \"%s\" does not exist" % src
+	else:
+		print "[-] The file \"%s\" already exists" % dst
+
+# -------------------------- For mv function --------------------------
+
+def rm(path):
+	if os.path.exists(path):
+		if os.path.isdir(path):
+			shutil.rmtree(path)
+		else:
+			os.remove(path)
+	else:
+		print "[-] The directory \"%s\" does not exists" % path
+
+# -------------------------- For cat function --------------------------
+
+def cat(path):
+	if os.path.exists(path):
+		if not os.path.isdir(path):
+			# not open files too big (< 7 Mo)
+			if os.path.getsize(path) < 7000000:
+				f = open(path, 'r')
+				print f.read()
+				f.close()
+			else:
+				print "[-] \"%s\" is too big to be openned (max size: 7 Mo)" % path
+		else:
+			print "[-] \"%s\" is a directory" % path
+					
+	else:
+		print "[-] The file \"%s\" does not exists" % path

--- a/pupy/pupy.conf.default
+++ b/pupy/pupy.conf.default
@@ -40,6 +40,11 @@ getppid = getppid
 pwd = pyexec -c 'import os;print os.getcwd()'
 #tasklist = shell_exec 'tasklist /v'
 creds = creds -S
+ls = ls
+cd = cd
+mkdir = mkdir
+rm = rm
+cat = cat
 
 [rubber_ducky]
 #path to the encoder.jar file of Rubber-Ducky project (see https://github.com/hak5darren/USB-Rubber-Ducky/blob/master/Encoder/encoder.jar)


### PR DESCRIPTION
I have implemented basic commands that could be useful for file system management. 
It will be possible to browse and realise actions on file system without needed to prompt the shell. 

I have seen a problem when the module has 2 positional arguments. When I put the alias on the pupy.conf, it won't see the second arguments. 
That's why I didn't put the "cp" and "mv" module on the pupy.conf file. To see the error, try to add "cp=cp" on the configuration file, it won't work. 

It would be nice to add an option on the class (it already exists: "unique_instance=True", "daemon=True", so I imagine something like "ismodule=True"), to specify if it has to be shown as a module or not. For me, these kind of modules should not have to be listed as a module (and it has not to be listed with "list_modules"). For me "ps", "getpid", "getppid" "drives", "creds", "info", "exit" are not modules. 