### PR TITLE
Fix error powershell delivery and list sids

### DIFF
--- a/pupy/packages/windows/all/pupwinutils/security.py
+++ b/pupy/packages/windows/all/pupwinutils/security.py
@@ -7,6 +7,7 @@ from ctypes import *
 import subprocess
 import psutil
 import ctypes
+import platform
 
 LPVOID = c_void_p
 PVOID = LPVOID
@@ -218,6 +219,11 @@ def EnablePrivilege(privilegeStr, hToken = None):
 
 def ListSids():
     sids=[]
+
+    # A well know bug in windows version > 8 (major >= 6.2) occurs when a "GetTokenSid" function is called from a 64 bits process. Stop it before its call
+    win_version = float("%s.%s" % (sys.getwindowsversion()[0], sys.getwindowsversion()[1]))
+    if "64" in platform.architecture()[0] and win_version > 6.1:
+        raise OSError("Can't let you to do that because a well known bug is not fixed yet, migrate to a 32 bits process and run this action again.\nEx: run migrate -c \'C:\\Windows\\SysWOW64\\notepad.exe\'")
 
     for proc in psutil.process_iter():
         try:

--- a/pupy/pupylib/payloads/ps1_oneliner.py
+++ b/pupy/pupylib/payloads/ps1_oneliner.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF8 -*-
+# Code inspired from the awesome tool CrackMapExec: https://github.com/byt3bl33d3r/CrackMapExec/blob/b1e83227047a64cbe45145b8ebf5054640822317/cme/modules/pe_inject.py
+# Thanks to byt3bl33d3r
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 import os.path
 from pupylib.utils.term import colorize


### PR DESCRIPTION
Hi, 

During tests, I have seen lots of bugs with the ps1_oneliner. It didn't work on old Windows versions (such as windows server 2003). Many times, the error occurs saying that the aes decrypt function was not present. So I have changed the process to deliver the ps1 payload to work using basic powershell functions. I have used the code written in crackmapexec (thanks to byt3bl33d3r if he reads it):
- https://github.com/byt3bl33d3r/CrackMapExec/blob/b1e83227047a64cbe45145b8ebf5054640822317/cme/modules/pe_inject.py 

It forces a 32 bits instance of powershell, so only x86 dll will be delivered even on x64 bits arch. Using this technic, I got a shell on old Windows version. 

Moreover, I tested it on Windows 8.1 and Windows 10 using "impersonate -l" and "getsystem" function and everything was ok. So I have added a check when calling these functions to not allow the user to do it from a 64 bits process in order to keep the active session alive (#124). 

So this fix is a workaround before to understand the real problem. However, everything works ok now. 