### PR TITLE
changing list_modules and help functions

### DIFF
--- a/pupy/pupylib/PupyCmd.py
+++ b/pupy/pupylib/PupyCmd.py
@@ -341,7 +341,7 @@ class PupyCmd(cmd.Cmd):
             for command,doc in cmds_doc:
                 if doc is None:
                     doc=""
-                self.stdout.write("- {:<10}    {}\n".format(command, color(doc.strip(),'grey')))
+                self.stdout.write("- {:<15}    {}\n".format(command, color(doc.title().strip(),'grey')))
     
     @staticmethod
     def format_log(msg):
@@ -427,12 +427,21 @@ class PupyCmd(cmd.Cmd):
     
     def do_list_modules(self, arg):
         """ List available modules with a brief description (the first description line) """
+        system = ''
+        if self.default_filter:
+            system = self.pupsrv.get_clients(self.default_filter)[0].desc['platform'].lower()
+            self.display_success("List modules compatible with the selected host: %s" % system)
+        else:
+            self.display_success("List all modules")
+
         for mod in sorted([x for x in self.pupsrv.iter_modules()], key=(lambda x:x.category)):
-            doc=mod.__doc__
-            if not doc:
-                doc=""
-            doc=doc.strip()
-            self.stdout.write("{:<20}    {}\n".format("%s/%s"%(mod.category,mod.get_name()), color(doc.split("\n",1)[0],'grey')))
+            if mod.is_module:
+                if (self.default_filter and (system in mod.compatible_systems or not mod.compatible_systems)) or (not self.default_filter):
+                    if mod.__doc__: 
+                        doc = mod.__doc__.strip()
+                    else:
+                       doc = ''
+                    self.stdout.write("{:<25}    {}\n".format("%s/%s"%(mod.category,mod.get_name()), color(doc.title().split("\n",1)[0],'grey')))
 
     def do_sessions(self, arg):
         """ list/interact with established sessions """


### PR DESCRIPTION
I have changed the list modules function to print only modules (not basic functions such as ls, cat, etc.). Moreover, when a host is selected, only compatible modules are printed (#103). I have added the "title" function, if you prefer to use only "capitalize", do it as you prefer. 

