### PR TITLE
fix port_scan bug

### DIFF
--- a/pupy/packages/all/portscan.py
+++ b/pupy/packages/all/portscan.py
@@ -34,6 +34,9 @@ class WorkerThread(threading.Thread) :
             self.queue.task_done()
 
 def scan(remote_ip, ports, nb_threads, settimeout):
+    global open_port
+    open_port = []
+    
     queue = Queue.Queue()
     threads = []
 


### PR DESCRIPTION
When you realised a port scan, the open_port variable was never restored to empty so the return value was not correct. This pull request fixed that problem. 