### PR TITLE
fix ps encoding bug

### DIFF
--- a/pupy/modules/ps.py
+++ b/pupy/modules/ps.py
@@ -30,7 +30,7 @@ class PsModule(PupyModule):
             else:
                 for dic in outputlist:
                     if 'exe' in dic and not dic['exe'] and 'name' in dic and dic['name']:
-                        dic['exe']=dic['name']
+                        dic['exe']=dic['name'].encode('utf-8', errors='replace')
                     if 'username' in dic and dic['username'] is None:
                         dic['username']=""
             self.rawlog(self.formatter.table_format(outputlist, wl=columns))


### PR DESCRIPTION
I had this issue, encoding it fixed it: 

```
>> run admin/ps
[-] 'utf8' codec can't decode byte 0xe9 in position 69: invalid continuation byte

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\rpyc\core\protocol.py", line 305, in _dispatch_request
  File "C:\Python27\lib\site-packages\rpyc\core\protocol.py", line 535, in _handle_call
  File "<string>", line 129, in exposed_json_dumps
  File "C:\Python27\lib\json\__init__.py", line 244, in dumps
  File "C:\Python27\lib\json\encoder.py", line 207, in encode
  File "C:\Python27\lib\json\encoder.py", line 270, in iterencode
UnicodeDecodeError: 'utf8' codec can't decode byte 0xe9 in position 69: invalid continuation byte


```