### PR TITLE
fix cd bug

### DIFF
--- a/pupy/packages/all/pupyutils/basic_cmds.py
+++ b/pupy/packages/all/pupyutils/basic_cmds.py
@@ -79,8 +79,11 @@ def ls(path=None):
 def cd(path=None):
     if not path:
         home = os.path.expanduser("~")
-        os.chdir(home)
-        return
+        try:
+            os.chdir(home)
+            return
+        except:
+            return "[-] Home directory not found (or access denied): %s" % home
     
     path = os.path.join(os.getcwd(), path)
     if os.path.isdir(path):


### PR DESCRIPTION
I had this issue (I had system privileges, but I think the path didn't exist) : 

```
>> cd (quand system)
[-] (5, 'Access is denied')

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\rpyc\core\protocol.py", line 305, in _dispatch_request
  File "C:\Python27\lib\site-packages\rpyc\core\protocol.py", line 535, in _handle_call
  File "<memimport>/pupyutils/basic_cmds.py", line 82, in cd
WindowsError: [Error 5] Access is denied: 'C:\\Windows\\system32\\config\\systemprofile'

```