### PR TITLE
fix lazagne error

### DIFF
--- a/pupy/packages/windows/all/laZagne.py
+++ b/pupy/packages/windows/all/laZagne.py
@@ -26,6 +26,8 @@ from lazagne.config.constant import *
 from lazagne.config.manageModules import get_categories, get_modules
 from lazagne.config.changePrivileges import ListSids, rev2self, impersonate_sid_long_handle
 
+sys.setrecursionlimit(10000) # workaround to this error: RuntimeError: maximum recursion depth exceeded while calling a Python object
+
 # Tab containing all passwords
 stdoutRes = []
 


### PR DESCRIPTION
I think, it's not a beautiful fix but it worked. I don't know why I have this error because I don't use recursion functions. Maybe, it doesn't like using yield or another external lib (as colorama) used recursion. However, this trick fixed the issue. 

```
>> run lazagne 
[-] maximum recursion depth exceeded while calling a Python object

========= Remote Traceback (1) =========
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\rpyc\core\protocol.py", line 305, in _dispatch_request
  File "C:\Python27\lib\site-packages\rpyc\core\protocol.py", line 547, in _handle_callattr
  File "<memimport>/laZagne.py", line 245, in runLaZagne
  File "<memimport>/colorama/ansitowin32.py", line 40, in write
  File "<memimport>/colorama/ansitowin32.py", line 141, in write
  File "<memimport>/colorama/ansitowin32.py", line 169, in write_and_convert
  File "<memimport>/colorama/ansitowin32.py", line 174, in write_plain_text
  File "<memimport>/colorama/ansitowin32.py", line 40, in write
  File "<memimport>/colorama/ansitowin32.py", line 141, in write
  File "<memimport>/colorama/ansitowin32.py", line 169, in write_and_convert
  File "<memimport>/colorama/ansitowin32.py", line 174, in write_plain_text
  File "<memimport>/colorama/ansitowin32.py", line 40, in write
  File "<memimport>/colorama/ansitowin32.py", line 141, in write 
```