### PR TITLE
removing duplicate value

### DIFF
--- a/pupy/pupylib/PupyPackagesDependencies.py
+++ b/pupy/pupylib/PupyPackagesDependencies.py
@@ -30,11 +30,6 @@ packages_dependencies={
     "pyaudio" : [
         (LOAD_PACKAGE, ALL_OS, "_portaudio"),
     ],
-    "scapy" : [
-        (LOAD_PACKAGE, ALL_OS, "gzip"),
-        (LOAD_PACKAGE, ALL_OS, "_strptime"),
-        (LOAD_PACKAGE, ALL_OS, "calendar"),
-    ],
     "OpenSSL" : [
         (LOAD_PACKAGE, ALL_OS, "six"),
         (LOAD_PACKAGE, ALL_OS, "enum"),


### PR DESCRIPTION
The "scapy" tab is duplicated on the packages_dependencies dictionary. 