### PR TITLE
updating requirements to include PIL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ecdsa==0.13
 paramiko==2.0.2
 netifaces
 mss
+Pillow


### PR DESCRIPTION
[%] device 0 exists, taking a snap ...
[-] No module named PIL

is produced if pillow isn't installed