### PR TITLE
Fixing the screenshots module to create the directory before saving the screenshot

### DIFF
--- a/pupy/modules/screenshot.py
+++ b/pupy/modules/screenshot.py
@@ -71,10 +71,11 @@ class screenshoter(PupyModule):
             self.error(error)
         else:
             self.success('number of monitor detected: %s' % str(len(screenshots)))
-            # Tring to make the directory before attempting to save there
             try:
-                makedirs(path.join("data", "screenshots"))
-            except Exception as e:
+                # If the directory doesnt exist then try to create it
+                if not path.isdir("data/screenshots"):
+                    makedirs(path.join("data", "screenshots"))
+            except Exception as error:
                 self.error("Couldn't create the directory data/screenshots %s" % error)
 
             for screenshot in screenshots:

--- a/pupy/modules/screenshot.py
+++ b/pupy/modules/screenshot.py
@@ -73,9 +73,9 @@ class screenshoter(PupyModule):
             self.success('number of monitor detected: %s' % str(len(screenshots)))
             # Tring to make the directory before attempting to save there
             try:
-                makedirs(path.join("data", "webcam_snaps"))
+                makedirs(path.join("data", "screenshots"))
             except Exception as e:
-                self.error("Couldn't create the directory data/webcam_snaps %s" % error)
+                self.error("Couldn't create the directory data/screenshots %s" % error)
 
             for screenshot in screenshots:
                 filepath = path.join("data","screenshots","scr_"+self.client.short_name()+"_"+str(datetime.datetime.now()).replace(" ","_").replace(":","-")+".png")

--- a/pupy/modules/screenshot.py
+++ b/pupy/modules/screenshot.py
@@ -31,7 +31,7 @@
 # --------------------------------------------------------------
 
 from pupylib.PupyModule import *
-from os import path
+from os import path, makedirs
 
 import time
 import datetime
@@ -71,7 +71,12 @@ class screenshoter(PupyModule):
             self.error(error)
         else:
             self.success('number of monitor detected: %s' % str(len(screenshots)))
-            
+            # Tring to make the directory before attempting to save there
+            try:
+                makedirs(path.join("data", "webcam_snaps"))
+            except Exception as e:
+                self.error("Couldn't create the directory data/webcam_snaps %s" % error)
+
             for screenshot in screenshots:
                 filepath = path.join("data","screenshots","scr_"+self.client.short_name()+"_"+str(datetime.datetime.now()).replace(" ","_").replace(":","-")+".png")
                 with open(filepath, 'w') as out:


### PR DESCRIPTION
When you run the screenshot  module on a fresh install of puppy 

```
>> run screenshot
[+] number of monitor detected: 1
[-] [Errno 2] No such file or directory: 'data/screenshots/scr_win_DESKTOP-AQBK0DH_080027797E10_2017-03-17_10-35-21.522278.png'
```

You got an error message stating that the screenshot directory didn't already exist. But when you run the other modules they automatically create the directory.

I updated the module to create the directory if it doesn't already exist.