### PR TITLE
Fix pupygen socketserver import

### DIFF
--- a/pupy/network/lib/picocmd/server.py
+++ b/pupy/network/lib/picocmd/server.py
@@ -14,7 +14,7 @@ import functools
 import logging
 
 import socket
-import socketserver
+import SocketServer
 
 from dnslib import DNSRecord, RR, QTYPE, A, RCODE
 from dnslib.server import DNSServer, DNSHandler, BaseResolver, DNSLogger


### PR DESCRIPTION
When running pupygen.py in python2, there's an import error because `socketserver` is the python3 name for the module.  Replace with `SocketServer` for python2 compatibility.