### PR TITLE
ps1_oneliner improvements

### DIFF
--- a/pupy/pupygen.py
+++ b/pupy/pupygen.py
@@ -425,6 +425,7 @@ def get_parser(base_parser, config):
     parser.add_argument('--randomize-hash', action='store_true', help="add a random string in the exe to make it's hash unknown")
     parser.add_argument('--oneliner-listen-port', default=8080, type=int, help="Port used by ps1_oneliner locally (default: %(default)s)")
     parser.add_argument('--oneliner-no-ssl', default=False, action='store_true', help="No ssl for ps1_oneliner stages (default: %(default)s)")
+    parser.add_argument('--oneliner-nothidden', default=False, action='store_true', help="Powershell script not hidden target side (default: %(default)s)")
     parser.add_argument('--debug-scriptlets', action='store_true', help="don't catch scriptlets exceptions on the client for debug purposes")
     parser.add_argument('--debug', action='store_true', help="build with the debug template (the payload open a console)")
     parser.add_argument('--workdir', help='Set Workdir (Default = current workdir)')
@@ -623,7 +624,7 @@ def pupygen(args, config):
         else: sslEnabled = False
         if args.no_use_proxy == False : useTargetProxy = True
         else: useTargetProxy = False
-        serve_ps1_payload(conf, link_ip=link_ip, port=args.oneliner_listen_port, useTargetProxy=useTargetProxy, sslEnabled=sslEnabled)
+        serve_ps1_payload(conf, link_ip=link_ip, port=args.oneliner_listen_port, useTargetProxy=useTargetProxy, sslEnabled=sslEnabled, nothidden=args.oneliner_nothidden)
     elif args.format=="rubber_ducky":
         rubber_ducky(conf).generateAllForOStarget()
     else:


### PR DESCRIPTION
- _**oneliner-nothidden**_ option for _ps1_oneliner_ module.
- _**oneliner-no-ssl**_ option for _ps1_oneliner_ module.
- SSL bug fix in _ps1_oneliner_ (and other bugs): _ps1_oneliner_ server needs to allow <=TLSv1. On Kali, server allows >=TLS2.0 only by default.
- Improvements in ps1_oneliner: 
   -> If x64 target => x64 dll used and if x86 target => x64 dll used. "Force x86" is not used anymore (AV evasion).
   -> Stages are encoded (but not obfuscated).

Notice: for bypassing some AV: needs to use _--oneliner-no-ssl_ **+** _--oneliner-nothidden_ **+** not encoded version. I will modify the source code later for bypassing AV in other cases