### PR TITLE
from scapy.layers.inet6 import IPv6

### DIFF
--- a/pupy/packages/all/pupyutils/netcreds.py
+++ b/pupy/packages/all/pupyutils/netcreds.py
@@ -11,6 +11,7 @@ import scapy.arch
 
 from scapy.packet import Raw
 from scapy.layers.inet import IP,UDP,TCP
+from scapy.layers.inet6 import IPv6
 from scapy.layers.l2 import Ether
 from scapy.layers.snmp import SNMP
 from scapy.config import conf


### PR DESCRIPTION
IPv6 is used on line 199 but is never imported or defined.
* https://travis-ci.org/n1nj4sec/pupy/builds/325378790#L654-L656