### PR TITLE
Fix udp_secure info

### DIFF
--- a/pupy/network/transports/udp_secure/conf.py
+++ b/pupy/network/transports/udp_secure/conf.py
@@ -7,7 +7,7 @@ from network.lib import PupyUDPServer, PupyUDPClient, PupyUDPSocketStream
 from network.lib import RSA_AESClient, RSA_AESServer, DummyPupyTransport
 
 class TransportConf(Transport):
-    info = "Simple UDP transport transmitting in cleartext"
+    info = "Simple UDP transport transmitting with RSA"
     name="udp_secure"
     server=PupyUDPServer
     client=PupyUDPClient


### PR DESCRIPTION
I saw an error in the info string while exploring transports. Let me know if this could be worded better.