### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -10,4 +10,4 @@ u-msgpack-python
 win_inet_pton
 dnslib
 dukpy
-zeroconf=0.19.1
+zeroconf==0.19.1


### PR DESCRIPTION


Invalid requirement: 'zeroconf=0.19.1'
= is not a valid operator. Did you mean == ?