### PR TITLE
Travis CI: Do not hard-code Trusty, it EOLs next month

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
 - docker
 os:
 - linux
-dist: trusty
 before_script:
   - sudo pip2 install flake8 flake8-per-file-ignores
   - cd $TRAVIS_BUILD_DIR/pupy && python2 -m flake8 .


### PR DESCRIPTION
Do not hard-code __Trusty__ because it reaches its end-of-life next month.
https://wiki.ubuntu.com/Releases