### PR TITLE
Fix Python  version < 2.7.9 error

### DIFF
--- a/pupy/scriptlets/__init__.py
+++ b/pupy/scriptlets/__init__.py
@@ -331,8 +331,7 @@ def parse_scriptlet(filedir, filename):
 
     metadata = compile(meta, 'metadata-'+filename, 'exec')
     metadict = {}
-    exec (metadata, metadict)
-    del metadict['__builtins__']
+    eval(metadata, globals(), metadict)
 
     docstring = '\n'.join(
         x.strip() for x in docstrings


### PR DESCRIPTION
The tuple form has not always been 100 % compatible, as there was a bug in handling of exec in functions with nested functions (issue 21591);
Reference: https://stackoverflow.com/a/41368813

Error info:
```
Python 2.7.5 (default, Apr  2 2020, 13:16:51) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from scriptlets import load_scriptlets
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "scriptlets/__init__.py", line 334
    exec(metadata, metadict)
SyntaxError: unqualified exec is not allowed in function 'parse_scriptlet' it contains a nested function with free variables
```