### PR TITLE
Rsa is compatible with Python 3.5+ only.

### DIFF
--- a/client/sources/build-docker.sh
+++ b/client/sources/build-docker.sh
@@ -3,7 +3,7 @@
 PACKAGES_BUILD="netifaces msgpack-python u-msgpack-python construct bcrypt watchdog dukpy impacket zeroconf==0.19.1"
 PACKAGES_BUILD="$PACKAGES_BUILD pycryptodomex pycryptodome cryptography pyOpenSSL paramiko"
 
-PACKAGES="rsa pefile rsa netaddr==0.7.19 win_inet_pton pypiwin32 poster win_inet_pton dnslib"
+PACKAGES="rsa==4.0 pefile netaddr==0.7.19 win_inet_pton pypiwin32 poster win_inet_pton dnslib"
 PACKAGES="$PACKAGES pyaudio https://github.com/secdev/scapy/archive/master.zip colorama pyaudio"
 PACKAGES="$PACKAGES https://github.com/alxchk/pypykatz/archive/master.zip"
 PACKAGES="$PACKAGES https://github.com/warner/python-ed25519/archive/master.zip"

--- a/pupy/requirements.txt
+++ b/pupy/requirements.txt
@@ -1,7 +1,7 @@
 pycryptodome
 pefile 
 pyyaml
-rsa
+rsa==4.0
 netaddr
 ecdsa==0.13
 paramiko==2.0.2


### PR DESCRIPTION
Rsa Version 4.0 was the last version to support Python 2 and 3.4. Version 4.1 is compatible with Python 3.5+ only.