### PR TITLE
Futurize branch: pupy/pupylib/PupyWeb.py, replaced deprecated decorator web.asynchronous

### DIFF
--- a/pupy/pupylib/PupyWeb.py
+++ b/pupy/pupylib/PupyWeb.py
@@ -129,8 +129,7 @@ class StaticTextHandler(TornadoRequestHandler):
     def set_default_headers(self):
         self.set_header('Server', SERVER_HEADER)
 
-    @tornado.web.asynchronous
-    def get(self):
+    async def get(self):
         self.finish(self.content)
 
 
@@ -180,8 +179,7 @@ class IndexHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
         self.set_header('Server', SERVER_HEADER)
 
-    @tornado.web.asynchronous
-    def get(self):
+    async def get(self):
         if self.request.remote_ip in self.local_ips:
             self.render("index.html")
         else:


### PR DESCRIPTION
Replaced web.asynchronous which was deprecated since version 5.1 to be used with native coroutines.