### PR TITLE
removed a default mutable argument pitfall

### DIFF
--- a/create-workspace.py
+++ b/create-workspace.py
@@ -309,14 +309,15 @@ def initialize_workdir(workdir, gitdir):
     )
 
 
-def create_virtualenv(workdir, git_path, orchestrator=None, templates=[]):
+def create_virtualenv(workdir, git_path, orchestrator=None, templates=None):
     import virtualenv
 
     if hasattr(virtualenv, 'create_environment'):
         virtualenv.create_environment(workdir)
     else:
         virtualenv.cli_run([workdir])
-
+    if not templates:
+        templates = []
     print("[+] Update pip version ...")
     subprocess.check_call([
         os.path.join(workdir, 'bin', 'pip'),


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in method, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**the solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument