### PR TITLE
Fix error: ‘Py_UCS1’ undeclared

### DIFF
--- a/pupy/conf/Dockerfile.env
+++ b/pupy/conf/Dockerfile.env
@@ -25,7 +25,7 @@ RUN \
 COPY requirements.txt /build/
 
 RUN \
-	python -m pip install --no-cache-dir --upgrade pip six setuptools wheel && \
+	python -m pip install --no-cache-dir --upgrade pip six setuptools wheel && python -m pip install "regex<2022.1.18" && \
 		cd /build && \
 			python -m pip install --no-cache-dir --upgrade -r requirements.txt
 


### PR DESCRIPTION
Dropped support for Python 2 and remove all references to Python <3 (https://github.com/mrabarnett/mrab-regex/commit/227163df1b66a616e20a7f04424860540573949c)

Regex should use version < 2022.1.18